### PR TITLE
Moo less

### DIFF
--- a/modules/gametree.js
+++ b/modules/gametree.js
@@ -178,7 +178,7 @@ exports.getSections = function(tree, level) {
 
 exports.getWidth = function(y, matrix) {
     var keys = Object.keys(new Int8Array(10)).map(function(i) {
-        return parseFloat(i) + y - 4
+        return +i + y - 4
     }).filter(function(i) { return i >= 0 && i < matrix.length })
 
     var padding = Math.min.apply(null, keys.map(function(i) {

--- a/modules/helper.js
+++ b/modules/helper.js
@@ -3,6 +3,7 @@ var crypto = require('crypto')
 var shell = require('shell')
 
 var id = 0
+var storage = {}
 
 exports.getId = function() {
     return ++id
@@ -15,6 +16,15 @@ exports.md5 = function(str) {
 exports.roundEven = function(float) {
     var value = Math.round(float)
     return value % 2 == 0 ? value : value - 1
+}
+
+exports.store = function(key, value) {
+    storage.key = value
+}
+
+exports.retrieve = function(key, value) {
+    if (key in storage) return storage.key
+    return null
 }
 
 exports.equals = function(a, b) {

--- a/modules/helper.js
+++ b/modules/helper.js
@@ -22,15 +22,15 @@ exports.store = function(key, value) {
     return exports
 }
 
+exports.retrieve = function(key, value) {
+    if (key in storage) return storage[key]
+    return null
+}
+
 exports.li2vertex = function(li) {
     return [].filter.call(li.classList, function(x) {
         return x.indexOf('pos') == 0
     })[0].replace('pos_', '').split('-').map(function(x) { return +x })
-}
-
-exports.retrieve = function(key, value) {
-    if (key in storage) return storage[key]
-    return null
 }
 
 exports.equals = function(a, b) {

--- a/modules/helper.js
+++ b/modules/helper.js
@@ -19,11 +19,11 @@ exports.roundEven = function(float) {
 }
 
 exports.store = function(key, value) {
-    storage.key = value
+    storage[key] = value
 }
 
 exports.retrieve = function(key, value) {
-    if (key in storage) return storage.key
+    if (key in storage) return storage[key]
     return null
 }
 

--- a/modules/helper.js
+++ b/modules/helper.js
@@ -40,8 +40,8 @@ exports.equals = function(a, b) {
     var t = Object.prototype.toString.call(a)
     if (t !== Object.prototype.toString.call(b)) return false
 
-    var aa = t === "[object Array]"
-    var ao = t === "[object Object]"
+    var aa = t === '[object Array]'
+    var ao = t === '[object Object]'
 
     if (aa) {
         if (a.length !== b.length) return false

--- a/modules/helper.js
+++ b/modules/helper.js
@@ -1,4 +1,3 @@
-var gtp = require('./gtp')
 var crypto = require('crypto')
 var shell = require('shell')
 
@@ -21,6 +20,12 @@ exports.roundEven = function(float) {
 exports.store = function(key, value) {
     storage[key] = value
     return exports
+}
+
+exports.li2vertex = function(li) {
+    return [].filter.call(li.classList, function(x) {
+        return x.indexOf('pos') == 0
+    })[0].replace('pos_', '').split('-').map(function(x) { return +x })
 }
 
 exports.retrieve = function(key, value) {
@@ -101,7 +106,7 @@ exports.wireLinks = function(container) {
         return false
     })
     container.getElements('.coord').addEvent('mouseenter', function() {
-        var v = gtp.point2vertex(this.get('text'), getBoard().size)
+        var v = require('./gtp').point2vertex(this.get('text'), getBoard().size)
         showIndicator(v)
     }).addEvent('mouseleave', function() {
         hideIndicator()

--- a/modules/helper.js
+++ b/modules/helper.js
@@ -20,6 +20,7 @@ exports.roundEven = function(float) {
 
 exports.store = function(key, value) {
     storage[key] = value
+    return exports
 }
 
 exports.retrieve = function(key, value) {

--- a/modules/sgf.js
+++ b/modules/sgf.js
@@ -141,7 +141,7 @@ exports.addBoard = function(tree, index, baseboard) {
         var prev = gametree.navigate(tree, index, -1)
 
         if (!prev[0]) {
-            var size = 'SZ' in node ? node.SZ[0].toInt() : 19
+            var size = 'SZ' in node ? +node.SZ[0] : 19
             baseboard = new Board(size)
         } else {
             var prevNode = prev[0].nodes[prev[1]]

--- a/view/index.js
+++ b/view/index.js
@@ -30,7 +30,7 @@ function setRootTree(tree, updateHash) {
     if (tree.nodes.length == 0) return
 
     tree.parent = null
-    if (updateHash) document.body.store('treehash', gametree.getHash(tree))
+    if (updateHash) helper.store('treehash', gametree.getHash(tree))
     setCurrentTreePosition(sgf.addBoard(tree), 0, true)
 
     setPlayerName(1, 'PB' in tree.nodes[0] ? tree.nodes[0].PB[0] : 'Black')
@@ -38,7 +38,7 @@ function setRootTree(tree, updateHash) {
 }
 
 function getGraphMatrixDict() {
-    return $('graph').retrieve('graphmatrixdict')
+    return helper.retrieve('graphmatrixdict')
 }
 
 function setGraphMatrixDict(matrixdict) {
@@ -47,7 +47,7 @@ function setGraphMatrixDict(matrixdict) {
     var s, graph
 
     try {
-        s = $('graph').retrieve('sigma')
+        s = helper.retrieve('sigma')
         graph = gametree.matrixdict2graph(matrixdict)
     } catch(e) { }
 
@@ -60,11 +60,11 @@ function setGraphMatrixDict(matrixdict) {
         setGraphMatrixDict(matrixdict)
     }
 
-    $('graph').store('graphmatrixdict', matrixdict)
+    helper.store('graphmatrixdict', matrixdict)
 }
 
 function getCurrentTreePosition() {
-    return $('goban').retrieve('position')
+    return helper.retrieve('treeposition')
 }
 
 function setCurrentTreePosition(tree, index, now) {
@@ -81,7 +81,7 @@ function setCurrentTreePosition(tree, index, now) {
 
     // Store new position
 
-    $('goban').store('position', [tree, index])
+    helper.store('treeposition', [tree, index])
     var redraw = !node
         || !gametree.onCurrentTrack(tree)
         || tree.collapsed && index == tree.nodes.length - 1
@@ -120,7 +120,7 @@ function getCurrentGraphNode() {
 
 function getGraphNode(tree, index) {
     var id = typeof tree === 'object' ? tree.id + '-' + index : tree
-    var s = $('graph').retrieve('sigma')
+    var s = helper.retrieve('sigma')
     return s.graph.nodes(id)
 }
 
@@ -145,16 +145,16 @@ function setSelectedTool(tool) {
 }
 
 function getBoard() {
-    return $('goban').retrieve('board')
+    return helper.retrieve('currentboard')
 }
 
 function setBoard(board) {
     if (!getBoard() || getBoard().size != board.size) {
-        $('goban').store('board', board)
+        helper.store('currentboard', board)
         buildBoard()
     }
 
-    $('goban').store('board', board)
+    helper.store('currentboard', board)
     setCaptures(board.captures)
 
     for (var x = 0; x < board.size; x++) {
@@ -240,12 +240,12 @@ function setUndoable(undoable) {
 
         document.body
             .addClass('undoable')
-            .store('undodata-root', rootTree)
+        helper.store('undodata-root', rootTree)
             .store('undodata-pos', position)
     } else {
         document.body
             .removeClass('undoable')
-            .store('undodata-root', null)
+        helper.store('undodata-root', null)
             .store('undodata-pos', null)
     }
 }
@@ -310,7 +310,7 @@ function prepareGameGraph() {
         openNodeMenu.apply(null, getTreePos(e))
     })
 
-    container.store('sigma', s)
+    helper.store('sigma', s)
 }
 
 function prepareSlider() {
@@ -1185,7 +1185,7 @@ function generateMove() {
 function centerGraphCameraAt(node) {
     if (!getShowSidebar() || !node) return
 
-    var s = $('graph').retrieve('sigma')
+    var s = helper.retrieve('sigma')
     s.renderers[0].resize().render()
 
     var matrixdict = getGraphMatrixDict()
@@ -1215,7 +1215,7 @@ function askForSave() {
     if (!getRootTree()) return true
     var hash = gametree.getHash(getRootTree())
 
-    if (hash != document.body.retrieve('treehash')) {
+    if (hash != helper.retrieve('treehash')) {
         var answer = showMessageBox(
             'Your changes will be lost if you close this game without saving.',
             'warning',
@@ -1321,7 +1321,7 @@ function saveGame() {
         var text = sgf.tree2string(tree)
 
         fs.writeFile(result, '(' + text + ')')
-        document.body.store('treehash', helper.md5(text))
+        helper.store('treehash', helper.md5(text))
     }
 
     setIsBusy(false)
@@ -1452,16 +1452,16 @@ function removeNode(tree, index) {
 }
 
 function undoBoard() {
-    if (document.body.retrieve('undodata-root') == null
-    || document.body.retrieve('undodata-pos') == null)
+    if (helper.retrieve('undodata-root') == null
+    || helper.retrieve('undodata-pos') == null)
         return
 
     setIsBusy(true)
 
     setTimeout(function() {
-        setRootTree(document.body.retrieve('undodata-root'))
+        setRootTree(helper.retrieve('undodata-root'))
 
-        var pos = gametree.navigate(getRootTree(), 0, document.body.retrieve('undodata-pos'))
+        var pos = gametree.navigate(getRootTree(), 0, helper.retrieve('undodata-pos'))
         setCurrentTreePosition.apply(null, pos)
 
         updateSidebar(true, true)

--- a/view/index.js
+++ b/view/index.js
@@ -222,15 +222,15 @@ function getKomi() {
 }
 
 function getEngineName() {
-    return $('console').retrieve('enginename')
+    return helper.retrieve('gtp-enginename')
 }
 
 function getEngineController() {
-    return $('console').retrieve('controller')
+    return helper.retrieve('gtp-controller')
 }
 
 function getEngineCommands() {
-    return $('console').retrieve('commands')
+    return helper.retrieve('gtp-commands')
 }
 
 function setUndoable(undoable) {
@@ -484,16 +484,16 @@ function attachEngine(exec, args) {
     setTimeout(function() {
         var split = require('argv-split')
         var controller = new gtp.Controller(exec, split(args))
-        controller.on('quit', function() { $('console').store('controller', null) })
-        $('console').store('controller', controller)
+        controller.on('quit', function() { helper.store('gtp-controller', null) })
+        helper.store('gtp-controller', controller)
 
         sendGTPCommand(new gtp.Command(null, 'name'), true, function(response) {
-            $('console').store('enginename', response.content)
+            helper.store('gtp-enginename', response.content)
         })
         sendGTPCommand(new gtp.Command(null, 'version'))
         sendGTPCommand(new gtp.Command(null, 'protocol_version'))
         sendGTPCommand(new gtp.Command(null, 'list_commands'), true, function(response) {
-            $('console').store('commands', response.content.split('\n'))
+            helper.store('gtp-commands', response.content.split('\n'))
         })
 
         syncEngine()
@@ -504,15 +504,15 @@ function detachEngine() {
     sendGTPCommand(new gtp.Command(null, 'quit'), true)
     clearConsole()
 
-    $('console').store('controller', null)
-        .store('boardhash', null)
+    helper.store('gtp-controller', null)
+        .store('gtp-boardhash', null)
 }
 
 function syncEngine() {
     var board = getBoard()
 
     if (!getEngineController()
-        || $('console').retrieve('boardhash') == board.getHash()) return
+        || helper.retrieve('gtp-boardhash') == board.getHash()) return
     if (!board.isValid()) {
         showMessageBox('GTP engines don’t support invalid board positions.', 'warning')
         return
@@ -537,7 +537,7 @@ function syncEngine() {
         }
     }
 
-    $('console').store('boardhash', board.getHash())
+    helper.store('gtp-boardhash', board.getHash())
     setIsBusy(false)
 }
 
@@ -703,7 +703,7 @@ function makeMove(vertex, sendCommand) {
             new gtp.Command(null, 'play', [color, gtp.vertex2point(vertex, getBoard().size)]),
             true
         )
-        $('console').store('boardhash', getBoard().getHash())
+        helper.store('gtp-boardhash', getBoard().getHash())
 
         setIsBusy(true)
         setTimeout(function() {
@@ -928,12 +928,12 @@ function vertexClicked(vertex) {
 }
 
 function updateSidebar(redraw, now) {
-    clearTimeout($('sidebar').retrieve('updatesidebarid'))
+    clearTimeout(helper.retrieve('updatesidebar-id'))
 
     var tp = getCurrentTreePosition()
     var tree = tp[0], index = tp[1]
 
-    $('sidebar').store('updatesidebarid', setTimeout(function() {
+    helper.store('updatesidebar-id', setTimeout(function() {
         if (!helper.equals(getCurrentTreePosition(), [tree, index]))
             return
 
@@ -1004,8 +1004,8 @@ function updateAreaMap() {
         return updateAreaMap()
     }
 
-    $('goban').store('areamap', map)
-        .store('finalboard', board)
+    helper.store('goban-areamap', map)
+        .store('goban-finalboard', board)
 }
 
 function commitCommentText() {
@@ -1143,7 +1143,7 @@ function sendGTPCommand(command, ignoreBlocked, callback) {
 
         // Update scrollbars
         var view = $$('#console .gm-scroll-view')[0]
-        var scrollbar = $('console').retrieve('scrollbar')
+        var scrollbar = helper.retrieve('console-scrollbar')
 
         view.scrollTo(0, view.getScrollSize().y)
         if (scrollbar) scrollbar.update()
@@ -1179,7 +1179,7 @@ function generateMove() {
         if (r.content.toLowerCase() != 'pass')
             v = gtp.point2vertex(r.content, getBoard().size)
 
-        $('console').store('boardhash', getBoard().makeMove(getCurrentPlayer(), v).getHash())
+        helper.store('gtp-boardhash', getBoard().makeMove(getCurrentPlayer(), v).getHash())
         makeMove(v, false)
     })
 }
@@ -1239,13 +1239,13 @@ function startAutoScroll(direction, delay) {
     delay = Math.max(setting.get('autoscroll.min_interval'), delay)
 
     var slider = $$('#sidebar .slider')[0]
-    clearTimeout(slider.retrieve('autoscrollid'))
+    clearTimeout(helper.retrieve('autoscroll-id'))
 
     if (direction > 0) goForward()
     else goBack()
     updateSlider()
 
-    slider.store('autoscrollid', setTimeout(function() {
+    helper.store('autoscroll-id', setTimeout(function() {
         startAutoScroll(direction, delay - setting.get('autoscroll.diff'))
     }, delay))
 }

--- a/view/index.js
+++ b/view/index.js
@@ -332,22 +332,23 @@ function prepareSlider() {
     slider.addEvent('mousedown', function() {
         if (event.buttons != 1) return
 
-        this.store('mousedown', true).addClass('active')
+        helper.store('slider-mousedown', true)
+        slider.addClass('active')
         document.fireEvent('mousemove')
     }).addEvent('touchstart', function() {
-        this.addClass('active')
+        slider.addClass('active')
     }).addEvent('touchmove', function(e) {
         var percentage = (e.client.y - slider.getPosition().y) / slider.getSize().y
         changeSlider(percentage)
     }).addEvent('touchend', function() {
-        this.removeClass('active')
+        slider.removeClass('active')
     })
 
     document.addEvent('mouseup', function() {
-        slider.store('mousedown', false)
-            .removeClass('active')
+        helper.store('slider-mousedown', false)
+        slider.removeClass('active')
     }).addEvent('mousemove', function() {
-        if (event.buttons != 1 || !slider.retrieve('mousedown'))
+        if (event.buttons != 1 || !helper.retrieve('slider-mousedown'))
             return
 
         var percentage = (event.clientY - slider.getPosition().y) / slider.getSize().y
@@ -357,12 +358,13 @@ function prepareSlider() {
     // Prepare previous/next buttons
 
     $$('#sidebar .slider a').addEvent('mousedown', function() {
-        this.store('mousedown', true)
+        helper.store((this.hasClass('next') ? 'next' : 'prev') + 'button-mousedown', true)
         startAutoScroll(this.hasClass('next') ? 1 : -1)
     })
 
     document.addEvent('mouseup', function() {
-        $$('#sidebar .slider a').store('mousedown', false)
+        helper.store('prevbutton-mousedown', false)
+            .store('nextbutton-mousedown', false)
     })
 }
 
@@ -1230,8 +1232,8 @@ function askForSave() {
 }
 
 function startAutoScroll(direction, delay) {
-    if (direction > 0 && !$$('#sidebar .slider a.next')[0].retrieve('mousedown')
-    || direction < 0 && !$$('#sidebar .slider a.prev')[0].retrieve('mousedown')) return
+    if (direction > 0 && !helper.retrieve('nextbutton-mousedown')
+    || direction < 0 && !helper.retrieve('prevbutton-mousedown')) return
 
     if (delay == null) delay = setting.get('autoscroll.max_interval')
     delay = Math.max(setting.get('autoscroll.min_interval'), delay)

--- a/view/index.js
+++ b/view/index.js
@@ -398,8 +398,8 @@ function prepareConsole() {
         if ([40, 38, 9].indexOf(e.code) != -1) e.preventDefault()
         var inputs = $$('#console form input')
 
-        if (this.retrieve('index') == null) this.store('index', inputs.indexOf(this))
-        var i = this.retrieve('index')
+        if (this.className == '') this.className = 'index_' + inputs.indexOf(this)
+        var i = +this.className.replace('index_', '')
         var length = inputs.length
 
         if ([38, 40].indexOf(e.code) != -1) {
@@ -412,7 +412,7 @@ function prepareConsole() {
             }
 
             this.value = i == length - 1 ? '' : inputs[i].value
-            this.store('index', i)
+            this.className = 'index_' + i
         } else if (e.code == 9) {
             // Tab
             var tokens = this.value.split(' ')

--- a/view/index.js
+++ b/view/index.js
@@ -106,7 +106,7 @@ function setCurrentTreePosition(tree, index, now) {
 
     if ('B' in tree.nodes[index]
     || 'PL' in tree.nodes[index] && tree.nodes[index].PL[0] == 'W'
-    || 'HA' in tree.nodes[index] && tree.nodes[index].HA[0].toInt() >= 1)
+    || 'HA' in tree.nodes[index] && +tree.nodes[index].HA[0] >= 1)
         currentplayer = -1
 
     setCurrentPlayer(currentplayer)
@@ -789,7 +789,7 @@ function useTool(vertex) {
 
                 if ('LB' in node) {
                     var list = node.LB.map(function(x) {
-                        return x.substr(3).toInt()
+                        return +x.substr(3)
                     }).filter(function(x) {
                         return !isNaN(x)
                     })
@@ -1045,7 +1045,7 @@ function commitGameInfo() {
     if (handicap == 0) delete rootNode.HA
     else rootNode.HA = [String.from(handicap + 1)]
 
-    var size = info.getElement('input[name="size"]').get('value').toInt()
+    var size = +info.getElement('input[name="size"]').value
     rootNode.SZ = [String.from(Math.max(Math.min(size, 26), 9))]
     if (isNaN(size)) rootNode.SZ = ['' + setting.get('game.default_board_size')]
 
@@ -1056,7 +1056,7 @@ function commitGameInfo() {
             delete rootNode.AB
         } else {
             var board = getBoard()
-            var stones = board.getHandicapPlacement(rootNode.HA[0].toInt())
+            var stones = board.getHandicapPlacement(+rootNode.HA[0])
             rootNode.AB = []
 
             for (var i = 0; i < stones.length; i++) {

--- a/view/index.js
+++ b/view/index.js
@@ -160,7 +160,7 @@ function setBoard(board) {
     for (var x = 0; x < board.size; x++) {
         for (var y = 0; y < board.size; y++) {
             var li = $('goban').getElement('.pos_' + x + '-' + y)
-            var sign = board.arrangement[li.retrieve('tuple')]
+            var sign = board.arrangement[helper.li2vertex(li)]
             var types = ['ghost_1', 'ghost_-1', 'circle', 'triangle',
                 'cross', 'square', 'label', 'point']
 
@@ -169,8 +169,8 @@ function setBoard(board) {
             })
             li.set('title', '')
 
-            if (li.retrieve('tuple') in board.overlays) {
-                var overlay = board.overlays[li.retrieve('tuple')]
+            if (helper.li2vertex(li) in board.overlays) {
+                var overlay = board.overlays[helper.li2vertex(li)]
                 var type = overlay[0], ghost = overlay[1], label = overlay[2]
 
                 if (type != '') li.addClass(type)
@@ -835,7 +835,7 @@ function useTool(vertex) {
         // Update SGF
 
         $$('#goban .row li').forEach(function(li) {
-            var v = li.retrieve('tuple')
+            var v = helper.li2vertex(li)
             if (!(v in board.overlays)) return
 
             var id = dictionary[board.overlays[v][0]]
@@ -987,14 +987,14 @@ function updateAreaMap() {
         if (li.hasClass('sign_1')) board.captures['-1']++
         else if (li.hasClass('sign_-1')) board.captures['1']++
 
-        board.arrangement[li.retrieve('tuple')] = 0
+        board.arrangement[helper.li2vertex(li)] = 0
     })
 
     var map = board.getAreaMap()
 
     $$('#goban .row li').forEach(function(li) {
         li.removeClass('area_-1').removeClass('area_0').removeClass('area_1')
-            .addClass('area_' + map[li.retrieve('tuple')])
+            .addClass('area_' + map[helper.li2vertex(li)])
     })
 
     var falsedead = $$('#goban .row li.area_-1.sign_-1.dead, #goban .row li.area_1.sign_1.dead')

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -1001,31 +1001,34 @@ document.addEvent('domready', function() {
 
     $$('.verticalresizer').addEvent('mousedown', function() {
         if (event.button != 0) return
-        this.getParent().store('initposx', [event.x, this.getParent().getStyle('width').toInt()])
+        helper.store(
+            this.getParent().id + '-initposx', 
+            [event.x, this.getParent().getStyle('width').toInt()]
+        )
     })
 
     $$('#sidebar .horizontalresizer').addEvent('mousedown', function() {
         if (event.button != 0) return
-        $('sidebar').store('initposy', [event.y, getCommentHeight()])
+        helper.store('sidebar-initposy', [event.y, getCommentHeight()])
         $('properties').setStyle('transition', 'none')
     })
 
     document.body.addEvent('mouseup', function() {
-        var sidebarInitPosX = $('sidebar').retrieve('initposx')
-        var leftSidebarInitPosX = $('leftsidebar').retrieve('initposx')
-        var initPosY = $('sidebar').retrieve('initposy')
+        var sidebarInitPosX = helper.retrieve('sidebar-initposx')
+        var sidebarInitPosY = helper.retrieve('sidebar-initposy')
+        var leftSidebarInitPosX = helper.retrieve('leftsidebar-initposx')
 
-        if (!sidebarInitPosX && !leftSidebarInitPosX && !initPosY) return
+        if (!sidebarInitPosX && !leftSidebarInitPosX && !sidebarInitPosY) return
 
         if (sidebarInitPosX) {
-            $('sidebar').store('initposx', null)
+            helper.store('sidebar-initposx', null)
             setting.set('view.sidebar_width', getSidebarWidth())
         } else if (leftSidebarInitPosX) {
-            $('leftsidebar').store('initposx', null)
+            helper.store('leftsidebar-initposx', null)
             setting.set('view.leftsidebar_width', getLeftSidebarWidth())
             return
-        } else if (initPosY) {
-            $('sidebar').store('initposy', null)
+        } else if (sidebarInitPosY) {
+            helper.store('sidebar-initposy', null)
             $('properties').setStyle('transition', '')
             setting.set('view.comments_height', getCommentHeight())
             setSidebarArrangement(true, true, false)
@@ -1034,11 +1037,11 @@ document.addEvent('domready', function() {
         if (helper.retrieve('sigma'))
             helper.retrieve('sigma').renderers[0].resize().render()
     }).addEvent('mousemove', function() {
-        var sidebarInitPosX = $('sidebar').retrieve('initposx')
-        var leftSidebarInitPosX = $('leftsidebar').retrieve('initposx')
-        var initPosY = $('sidebar').retrieve('initposy')
+        var sidebarInitPosX = helper.retrieve('sidebar-initposx')
+        var sidebarInitPosY = helper.retrieve('sidebar-initposy')
+        var leftSidebarInitPosX = helper.retrieve('leftsidebar-initposx')
 
-        if (!sidebarInitPosX && !leftSidebarInitPosX && !initPosY) return
+        if (!sidebarInitPosX && !leftSidebarInitPosX && !sidebarInitPosY) return
 
         if (sidebarInitPosX) {
             var initX = sidebarInitPosX[0], initWidth = sidebarInitPosX[1]
@@ -1055,8 +1058,8 @@ document.addEvent('domready', function() {
 
             helper.retrieve('console-scrollbar').update()
             return
-        } else if (initPosY) {
-            var initY = initPosY[0], initHeight = initPosY[1]
+        } else if (sidebarInitPosY) {
+            var initY = sidebarInitPosY[0], initHeight = sidebarInitPosY[1]
             var newheight = Math.min(Math.max(
                 initHeight + (initY - event.y) * 100 / $('sidebar').getSize().y,
                 setting.get('view.comments_minheight')

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -431,12 +431,12 @@ function readjustShifts(vertex) {
 
 function updateSidebarLayout() {
     var container = $$('#properties .gm-scroll-view')[0]
-    container.fade('hide')
+    container.setStyle('opacity', 0)
 
     setTimeout(function() {
         helper.retrieve('sigma').renderers[0].resize().render()
         helper.retrieve('properties-scrollbar').update()
-        container.set('tween', { duration: 200 }).fade('in')
+        container.setStyle('opacity', 1)
     }, 300)
 }
 
@@ -1002,7 +1002,7 @@ document.addEvent('domready', function() {
     $$('.verticalresizer').addEvent('mousedown', function() {
         if (event.button != 0) return
         helper.store(
-            this.getParent().id + '-initposx', 
+            this.getParent().id + '-initposx',
             [event.x, this.getParent().getStyle('width').toInt()]
         )
     })

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -460,12 +460,12 @@ function buildBoard() {
 
             ol.adopt(li.adopt(img)
                 .addEvent('mouseup', function() {
-                    if (!$('goban').retrieve('mousedown')) return
-                    $('goban').store('mousedown', false)
+                    if (!helper.retrieve('goban-mousedown')) return
+                    helper.store('goban-mousedown', false)
                     vertexClicked(this)
                 }.bind(vertex))
                 .addEvent('mousedown', function() {
-                    $('goban').store('mousedown', true)
+                    helper.store('goban-mousedown', true)
                 })
                 .grab(new Element('div', { class: 'area' }))
             )
@@ -959,7 +959,7 @@ document.addEvent('domready', function() {
     document.title = app.getName()
 
     document.body.addEvent('mouseup', function() {
-        $('goban').store('mousedown', false)
+        helper.store('goban-mousedown', false)
     })
 
     // Find bar buttons

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -3,7 +3,7 @@
  */
 
 function getMainMenu() {
-    return document.body.retrieve('mainmenu')
+    return helper.retrieve('mainmenu')
 }
 
 function getIsBusy() {
@@ -82,7 +82,7 @@ function setShowLeftSidebar(show) {
     var view = $$('#console .gm-scroll-view')[0]
     view.scrollTo(0, view.getScrollSize().y)
     view.getElement('form:last-child input').focus()
-    $('console').retrieve('scrollbar').update()
+    helper.retrieve('console-scrollbar').update()
 }
 
 function setLeftSidebarWidth(width) {
@@ -225,7 +225,7 @@ function setCommentText(text) {
 
     $$('#properties .gm-scroll-view')[0].scrollTo(0, 0)
     $$('#properties textarea')[0].scrollTo(0, 0)
-    $('properties').retrieve('scrollbar').update()
+    helper.retrieve('properties-scrollbar').update()
 }
 
 function getSliderValue() {
@@ -305,7 +305,7 @@ function setPreferencesTab(tab) {
     form.className = tab
 
     if (tab == 'engines')
-        $$('#preferences .engines-list')[0].retrieve('scrollbar').update()
+        helper.retrieve('engineslist-scrollbar').update()
 }
 
 /**
@@ -363,7 +363,7 @@ function addEngineItem(name, path, args) {
             events: {
                 click: function() {
                     this.getParent('li').dispose()
-                    $$('#preferences .engines-list')[0].retrieve('scrollbar').update()
+                    helper.retrieve('engineslist-scrollbar').update()
                 }
             }
         }).grab(new Element('img', {
@@ -375,7 +375,7 @@ function addEngineItem(name, path, args) {
     ul.grab(li)
     li.getElement('h3 input').focus()
 
-    var enginesScrollbar = $$('#preferences .engines-list')[0].retrieve('scrollbar')
+    var enginesScrollbar = helper.retrieve('engineslist-scrollbar')
     if (enginesScrollbar) enginesScrollbar.update()
 }
 
@@ -435,7 +435,7 @@ function updateSidebarLayout() {
 
     setTimeout(function() {
         helper.retrieve('sigma').renderers[0].resize().render()
-        $('properties').retrieve('scrollbar').update()
+        helper.retrieve('properties-scrollbar').update()
         container.set('tween', { duration: 200 }).fade('in')
     }, 300)
 }
@@ -534,13 +534,15 @@ function showIndicator(vertex) {
         .setStyle('left', li.getPosition().x)
         .setStyle('height', li.getSize().y)
         .setStyle('width', li.getSize().x)
-        .store('vertex', vertex)
+
+    helper.store('indicator-vertex', vertex)
 }
 
 function hideIndicator() {
     $('indicator').setStyle('top', '')
         .setStyle('left', '')
-        .store('vertex', null)
+
+    helper.store('indicator-vertex', null)
 }
 
 function buildMenu() {
@@ -804,7 +806,7 @@ function buildMenu() {
     ]
 
     var menu = Menu.buildFromTemplate(template)
-    document.body.store('mainmenu', menu)
+    helper.store('mainmenu', menu)
     Menu.setApplicationMenu(menu)
 }
 
@@ -857,7 +859,7 @@ function openNodeMenu(tree, index) {
 function clearConsole() {
     $$('#console .inner pre, #console .inner form:not(:last-child)').dispose()
     $$('#console .inner form:last-child input')[0].set('value', '').focus()
-    $('console').retrieve('scrollbar').update()
+    helper.retrieve('console-scrollbar').update()
 }
 
 /**
@@ -897,8 +899,8 @@ function closeGameInfo() {
 }
 
 function showScore() {
-    var board = $('goban').retrieve('finalboard')
-    var score = board.getScore($('goban').retrieve('areamap'))
+    var board = helper.retrieve('goban-finalboard')
+    var score = board.getScore(helper.retrieve('goban-areamap'))
     var rootNode = getRootTree().nodes[0]
 
     for (var sign = -1; sign <= 1; sign += 2) {
@@ -978,12 +980,12 @@ document.addEvent('domready', function() {
 
     // Properties scrollbar
 
-    $('properties').store('scrollbar', new Scrollbar({
+    helper.store('properties-scrollbar', new Scrollbar({
         element: $('properties'),
         createElements: false
     }).create())
 
-    $('console').store('scrollbar', new Scrollbar({
+    helper.store('console-scrollbar', new Scrollbar({
         element: $('console'),
         createElements: false
     }).create())
@@ -991,7 +993,7 @@ document.addEvent('domready', function() {
     // Engines list scrollbar
 
     var enginesList = $$('#preferences .engines-list')[0]
-    enginesList.store('scrollbar', new Scrollbar({
+    helper.store('engineslist-scrollbar', new Scrollbar({
         element: enginesList,
         createElements: false
     }).create())
@@ -1052,7 +1054,7 @@ document.addEvent('domready', function() {
             setLeftSidebarWidth(newwidth)
             resizeBoard()
 
-            $('console').retrieve('scrollbar').update()
+            helper.retrieve('console-scrollbar').update()
             return
         } else if (initPosY) {
             var initY = initPosY[0], initHeight = initPosY[1]
@@ -1064,6 +1066,6 @@ document.addEvent('domready', function() {
             setCommentHeight(newheight)
         }
 
-        $('properties').retrieve('scrollbar').update()
+        helper.retrieve('properties-scrollbar').update()
     })
 })

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -191,8 +191,8 @@ function setPlayerName(sign, name) {
 
 function getCaptures() {
     return {
-        '-1': $$('#player_-1 .captures')[0].get('text').toInt(),
-        '1': $$('#player_1 .captures')[0].get('text').toInt()
+        '-1': +$$('#player_-1 .captures')[0].get('text'),
+        '1': +$$('#player_1 .captures')[0].get('text')
     }
 }
 
@@ -404,7 +404,7 @@ function readjustShifts(vertex) {
     var direction = li.get('class').split(' ').filter(function(x) {
         return x.indexOf('shift_') == 0
     }).map(function(x) {
-        return x.replace('shift_', '').toInt()
+        return +x.replace('shift_', '')
     })
 
     if (direction.length == 0) return
@@ -885,7 +885,7 @@ function showGameInfo() {
     size.set('value', 'SZ' in rootNode ? rootNode.SZ[0] : '')
 
     var handicap = info.getElement('select[name="handicap"]')
-    if ('HA' in rootNode) handicap.selectedIndex = Math.max(0, rootNode.HA[0].toInt() - 1)
+    if ('HA' in rootNode) handicap.selectedIndex = Math.max(0, +rootNode.HA[0] - 1)
     else handicap.selectedIndex = 0
 
     var disabled = tree.nodes.length > 1 || tree.subtrees.length > 0

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -451,7 +451,6 @@ function buildBoard() {
         for (var x = 0; x < board.size; x++) {
             var vertex = [x, y]
             var li = new Element('li.pos_' + x + '-' + y)
-                .store('tuple', vertex)
                 .addClass('shift_' + Math.floor(Math.random() * 9))
             var img = new Element('img', { src: '../img/goban/stone_0.png' })
 
@@ -492,7 +491,7 @@ function buildBoard() {
     // Readjust shifts
 
     $$('#goban .row li:not(.shift_0)').forEach(function(li) {
-        readjustShifts(li.retrieve('tuple'))
+        readjustShifts(helper.li2vertex(li))
     })
 }
 

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -113,7 +113,7 @@ function setShowSidebar(show) {
         updateCommentText();
     } else {
         // Clear game graph
-        var s = $('graph').retrieve('sigma')
+        var s = helper.retrieve('sigma')
 
         if (s) {
             s.graph.clear()
@@ -434,7 +434,7 @@ function updateSidebarLayout() {
     container.fade('hide')
 
     setTimeout(function() {
-        $('graph').retrieve('sigma').renderers[0].resize().render()
+        helper.retrieve('sigma').renderers[0].resize().render()
         $('properties').retrieve('scrollbar').update()
         container.set('tween', { duration: 200 }).fade('in')
     }, 300)
@@ -1030,8 +1030,8 @@ document.addEvent('domready', function() {
             setSidebarArrangement(true, true, false)
         }
 
-        if ($('graph').retrieve('sigma'))
-            $('graph').retrieve('sigma').renderers[0].resize().render()
+        if (helper.retrieve('sigma'))
+            helper.retrieve('sigma').renderers[0].resize().render()
     }).addEvent('mousemove', function() {
         var sidebarInitPosX = $('sidebar').retrieve('initposx')
         var leftSidebarInitPosX = $('leftsidebar').retrieve('initposx')


### PR DESCRIPTION
Get rid of Mootools

### Preprocess:

- [x] Remove `Element.store()` and `Element.retrieve()` calls
- [x] Remove `String.toInt()` calls
- [x] Remove `Tween` methods

### Replace Mootools by Sprint

- [x] Change `$` and `$$` calls
- [ ] Change `Element.setStyle()`
- [ ] Change event handling
- [ ] Change DOM manipulation