### PR TITLE
Replace Mootools with Sprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ This project is licensed under the [MIT license](https://github.com/yishn/Sabaki
 
 * [Electron](http://electron.atom.io/)
   ([MIT License](https://github.com/atom/electron/blob/master/LICENSE))
-* [MooTools](http://mootools.net/)
-  ([MIT License](https://github.com/mootools/mootools-core/blob/master/Source/license.txt))
+* [Sprint](https://github.com/philpl/sprint/)
+  ([MIT License](https://github.com/philpl/sprint/blob/master/LICENSE.txt))
 * [sigma](http://sigmajs.org/)
   ([MIT License](https://github.com/jacomyal/sigma.js/blob/master/LICENSE.txt))
 * [marked](https://github.com/chjj/marked)

--- a/main.js
+++ b/main.js
@@ -40,7 +40,7 @@ function newWindow(path) {
 
     window.loadURL('file://' + __dirname + '/view/index.html')
 
-    // if (setting.get('debug.dev_tools'))
+    if (setting.get('debug.dev_tools'))
         window.toggleDevTools()
 
     return window

--- a/main.js
+++ b/main.js
@@ -40,7 +40,7 @@ function newWindow(path) {
 
     window.loadURL('file://' + __dirname + '/view/index.html')
 
-    if (setting.get('debug.dev_tools'))
+    // if (setting.get('debug.dev_tools'))
         window.toggleDevTools()
 
     return window

--- a/modules/sprint.js
+++ b/modules/sprint.js
@@ -1,4 +1,14 @@
 /*
+ * This is a slightly altered version of Sprint.
+ *
+ * Added functions:
+ * - $.data()
+ *
+ * Fixed functions:
+ * - $.trigger()
+ */
+
+/*
  * Sprint JavaScript Library v0.9.2
  * http://sprintjs.com
  *

--- a/modules/sprint.js
+++ b/modules/sprint.js
@@ -1349,7 +1349,7 @@
       }
       return this.each(function() {
         getEventsToRemove(this, event).forEach(function(matchedEvent) {
-          this.dispatchEvent(new CustomEvent(matchedEvent, {
+          this.dispatchEvent(new window.CustomEvent(matchedEvent, {
             bubbles: true,
             cancelable: true
           }))

--- a/modules/sprint.js
+++ b/modules/sprint.js
@@ -1,0 +1,1433 @@
+/*
+ * Sprint JavaScript Library v0.9.2
+ * http://sprintjs.com
+ *
+ * Copyright (c) 2014, 2015 Benjamin De Cock
+ * Released under the MIT license
+ * http://sprintjs.com/license
+ */
+
+(function() {
+  "use strict";
+
+  var addEventListeners = function(listeners, el) {
+    var sprintClone = Sprint(el)
+    var events = Object.keys(listeners)
+    var eventsLen = events.length
+
+    for (var i = 0; i < eventsLen; i++) {
+      var event = events[i]
+      var handlers = listeners[event]
+      var handlersLen = handlers.length
+
+      for (var j = 0; j < handlersLen; j++) {
+        sprintClone.on(event, handlers[j])
+      }
+    }
+  }
+
+  var addPx = (function() {
+    var noPx = [
+      "animation-iteration-count",
+      "column-count",
+      "flex-grow",
+      "flex-shrink",
+      "font-weight",
+      "line-height",
+      "opacity",
+      "order",
+      "orphans",
+      "widows",
+      "z-index"
+    ]
+    return function addPx(cssProperty, value) {
+      if (inArray(cssProperty, noPx)) return value
+      var stringValue = typeof value == "string" ? value : value.toString()
+      if (value && !/\D/.test(stringValue)) {
+        stringValue += "px"
+      }
+      return stringValue
+    }
+  }())
+
+  var createDOM = function(HTMLString) {
+    var tmp = document.createElement("div")
+    var tag = /[\w:-]+/.exec(HTMLString)[0]
+    var inMap = wrapMap[tag]
+    var validHTML = HTMLString.trim()
+    if (inMap) {
+      validHTML = inMap.intro + validHTML + inMap.outro
+    }
+    tmp.insertAdjacentHTML("afterbegin", validHTML)
+    var node = tmp.lastChild
+    if (inMap) {
+      var i = inMap.outro.match(/</g).length
+      while (i--) {
+        node = node.lastChild
+      }
+    }
+    // prevent tmp to be node's parentNode
+    tmp.textContent = ""
+    return node
+  }
+
+  var domMethods = {
+    afterbegin: function(el) {
+      this.insertBefore(el, this.firstChild)
+    },
+    afterend: function(el) {
+      var parent = this.parentElement
+      parent && parent.insertBefore(el, this.nextSibling)
+    },
+    beforebegin: function(el) {
+      var parent = this.parentElement
+      parent && parent.insertBefore(el, this)
+    },
+    beforeend: function(el) {
+      this.appendChild(el)
+    }
+  }
+
+  var duplicateEventListeners = function(el, clone) {
+    // Element nodes only
+    if (el.nodeType > 1) return
+
+    // Duplicate event listeners for the parent element...
+    var listeners = getEvents(el)
+    listeners && addEventListeners(listeners, clone)
+
+    // ... and its descendants.
+    var descendants = selectElements("*", el)
+    var descendantsLen = descendants.length
+
+    // cloneDescendants is defined later to avoid calling selectElements() if not needed
+    var cloneDescendants
+
+    for (var i = 0; i < descendantsLen; i++) {
+      var listeners = getEvents(descendants[i])
+      if (!listeners) continue
+      if (!cloneDescendants) {
+        cloneDescendants = selectElements("*", clone)
+      }
+      addEventListeners(listeners, cloneDescendants[i])
+    }
+  }
+
+  var findAncestors = function(startAtParent, limitToParent, limitToFirstMatch, selector, context) {
+    var dom = []
+    var self = this
+    this.each(function() {
+      var prt = startAtParent ? this.parentElement : this
+      while (prt) {
+        if (context && context == prt) break
+        if (!selector || self.is(selector, prt)) {
+          dom.push(prt)
+          if (limitToFirstMatch) break
+        }
+        if (limitToParent) break
+        prt = prt.parentElement
+      }
+    })
+    return Sprint(removeDuplicates(dom))
+  }
+
+  var getEventFromNamespace = function(event) {
+    return splitNamespaces(event)[0]
+  }
+
+  var getEvents = function(domElement) {
+    return domElement.sprintEventListeners
+  }
+
+  var getEventsToRemove = function(domElement, event) {
+    /*
+     * Returns an array with the sprintEventListeners events matching potentially
+     * incomplete event names passed to .off().
+     * Example: .off("click.myPlugin") and .off("click.simple") would both remove a
+     * "click.myPlugin.simple" event.
+     */
+    return Object.keys(getEvents(domElement)).filter(function(prop) {
+      return splitNamespaces(event).every(function(name) {
+        return inArray(name, splitNamespaces(prop))
+      })
+    })
+  }
+
+  var getSetDimension = function(obj, prop, value) {
+    // get
+    if (value == null) {
+      var el = obj.get(0)
+      // return if el is neither element nor document node
+      if (!el || (el.nodeType > 1 && el.nodeType != 9)) return
+      var capitalizedProp = prop[0].toUpperCase() + prop.substring(1)
+      // dimension of HTML document
+      if (el == document) {
+        return Math.max(
+          el.body["scroll" + capitalizedProp] || 0,
+          el.body["offset" + capitalizedProp] || 0,
+          root["scroll" + capitalizedProp] || 0,
+          root["offset" + capitalizedProp] || 0
+        )
+      }
+      // dimension of viewport
+      if (el == window) {
+        return window["inner" + capitalizedProp]
+      }
+      // dimension of element
+      return el.getBoundingClientRect()[prop]
+    }
+
+    // set
+    var isFunction = typeof value == "function"
+    var stringValue = isFunction ? "" : addPx(prop, value)
+    return obj.each(function(index) {
+      if (this == document || this == window || this.nodeType > 1) return
+      if (isFunction) {
+        stringValue = addPx(prop, value.call(this, index, Sprint(this)[prop]()))
+      }
+      this.style[prop] = stringValue
+    })
+  }
+
+  var insertHTML = function(position, args) {
+    var argsLen = args.length
+    var contents = args
+
+    // reverse argument list for afterbegin and afterend
+    if (argsLen > 1 && position.indexOf("after") > -1) {
+      contents = []
+      var i = argsLen
+      while (i--) {
+        contents.push(args[i])
+      }
+    }
+
+    for (var i = 0; i < argsLen; i++) {
+      var content = contents[i]
+      if (typeof content == "string" || typeof content == "number") {
+        this.each(function() {
+          this.insertAdjacentHTML(position, content)
+        })
+      }
+      else if (typeof content == "function") {
+        this.each(function(index) {
+          var callbackValue = content.call(this, index, this.innerHTML)
+          insertHTML.call(Sprint(this), position, [callbackValue])
+        })
+      }
+      else {
+        var isSprintObj = content instanceof Init
+        var clonedElements = []
+        var elementsToInsert = (function() {
+          if (isSprintObj) {
+            return content.get()
+          }
+          if (Array.isArray(content)) {
+            return sanitize(content, true, true)
+          }
+          // DOM node
+          if (content.nodeType) {
+            return [content]
+          }
+          // getElementsByTagName, getElementsByClassName, querySelectorAll
+          return toArray(content)
+        }())
+        var elementsToInsertLen = elementsToInsert.length
+
+        this.each(function(index) {
+          /*
+           * The fragment serves multiple purposes:
+           * 1) It significantly boosts perf when multiple elements are added.
+           * 2) It avoids the need for elementsToInsert.reverse() for afterbegin and afterend
+           * 3) It removes an element from its original position before adding it back, which is
+           * especially useful for elements not part of the DOM tree. That means it's important even
+           * when elementsToInsertLen == 1.
+           */
+          var fragment = document.createDocumentFragment()
+          for (var i = 0; i < elementsToInsertLen; i++) {
+            var element = elementsToInsert[i]
+            var elementToInsert
+            if (index) {
+              elementToInsert = element.cloneNode(true)
+              duplicateEventListeners(element, elementToInsert)
+            }
+            else {
+              elementToInsert = element
+            }
+            fragment.appendChild(elementToInsert)
+            clonedElements.push(elementToInsert)
+          }
+          domMethods[position].call(this, fragment)
+        })
+
+        if (isSprintObj) {
+          content.dom = clonedElements
+          content.length = clonedElements.length
+        }
+        if (i < argsLen-1) continue
+        return clonedElements
+      }
+    }
+  }
+
+  var inArray = function(el, arr) {
+    var i = arr.length
+    while (i--) {
+      if (arr[i] === el) return true
+    }
+    return false
+  }
+
+  var isNamespaced = function(event) {
+    return /\./.test(event)
+  }
+
+  var manipulateClass = function(method, className, bool) {
+    if (className == null) {
+      if (method == "add") {
+        return this
+      }
+      return this.removeAttr("class")
+    }
+
+    var isString
+    var classNames
+    var classNamesLen
+
+    if (typeof className == "string") {
+      isString = true
+      classNames = className.trim().split(" ")
+      classNamesLen = classNames.length
+    }
+
+    return this.each(function(i, el) {
+      if (this.nodeType > 1) return
+      if (!isString) {
+        // className is a function
+        var callbackValue = className.call(el, i, el.className)
+        if (!callbackValue) return
+        classNames = callbackValue.trim().split(" ")
+        classNamesLen = classNames.length
+      }
+      for (var j = 0; j < classNamesLen; j++) {
+        var name = classNames[j]
+        if (!name) continue
+        bool == null
+          ? el.classList[method](name)
+          : el.classList.toggle(name, bool)
+      }
+    })
+  }
+
+  var matches = (function() {
+    var names = [
+      "mozMatchesSelector",
+      "webkitMatchesSelector",
+      "msMatchesSelector",
+      "matches"
+    ]
+    var i = names.length
+    while (i--) {
+      var name = names[i]
+      if (!Element.prototype[name]) continue
+      return name
+    }
+  }())
+
+  var removeDuplicates = function(arr) {
+    var clean = []
+    var cleanLen = 0
+    var arrLen = arr.length
+
+    for (var i = 0; i < arrLen; i++) {
+      var el = arr[i]
+      var duplicate = false
+
+      for (var j = 0; j < cleanLen; j++) {
+        if (el !== clean[j]) continue
+        duplicate = true
+        break
+      }
+
+      if (duplicate) continue
+      clean[cleanLen++] = el
+    }
+
+    return clean
+  }
+
+  var removeEvent = (function() {
+    var isHandlerShared = function(el, event, registeredHandler) {
+      var similarEventsHandlers = Object.keys(getEvents(el)).filter(function(prop) {
+        return getEventFromNamespace(event) === getEventFromNamespace(prop)
+      }).map(function(ev) {
+        return getEvents(el)[ev]
+      }).reduce(function(a, b) {
+        return a.concat(b)
+      }).filter(function(handler) {
+        return handler === registeredHandler
+      })
+      if (similarEventsHandlers.length < 2) return false
+      return true
+    }
+    var removeListener = function(el, event, namedHandler) {
+      return function(registeredHandler) {
+        if (namedHandler && namedHandler !== registeredHandler) return
+        el.removeEventListener(event, registeredHandler)
+        if (!isNamespaced(event) || isHandlerShared(el, event, registeredHandler)) return
+        el.removeEventListener(getEventFromNamespace(event), registeredHandler)
+      }
+    }
+    var clearRegisteredHandlers = function(registeredHandlers, namedHandler) {
+      return registeredHandlers.filter(function(handler) {
+        return namedHandler && namedHandler !== handler
+      })
+    }
+    return function(el, namedHandler) {
+      return function(event) {
+        getEvents(el)[event].forEach(removeListener(el, event, namedHandler))
+        getEvents(el)[event] = clearRegisteredHandlers(getEvents(el)[event], namedHandler)
+      }
+    }
+  }())
+
+  var removeMatchedEvents = function(el, namedHandler) {
+    return function(event) {
+      getEventsToRemove(el, event).forEach(removeEvent(el, namedHandler))
+    }
+  }
+
+  var root = document.documentElement
+
+  var sanitize = function(arr, flattenObjects, requireDomNodes) {
+    /*
+     * Remove null's from array. Optionally, flatten Sprint objects and convert strings and numbers
+     * to DOM text nodes.
+     */
+    var arrLen = arr.length
+    var i = arrLen
+
+    // Check if arr needs to be sanitized first (significant perf boost for the most common case)
+    while (i--) {
+      // arr needs to be sanitized
+      if ( (!arr[i] && arr[i] !== 0)
+        || (flattenObjects && arr[i] instanceof Init)
+        || (requireDomNodes && (typeof arr[i] == "string" || typeof arr[i] == "number"))
+      ) {
+        var sanitized = []
+        for (var j = 0; j < arrLen; j++) {
+          var el = arr[j]
+          if (!el && el !== 0) continue
+          if (flattenObjects && el instanceof Init) {
+            for (var k = 0; k < el.length; k++) {
+              sanitized.push(el.get(k))
+            }
+            continue
+          }
+          if (requireDomNodes && (typeof el == "string" || typeof el == "number")) {
+            sanitized.push(document.createTextNode(el))
+            continue
+          }
+          sanitized.push(el)
+        }
+        return sanitized
+      }
+    }
+
+    // arr didn't need to be sanitized, return it
+    return arr
+  }
+
+  var scroll = (function() {
+    var scrollRoot
+    return function(sprintObj, method, value) {
+      // define scroll root element on first run
+      if (!scrollRoot) {
+        var initialScrollPos = root.scrollTop
+        root.scrollTop = initialScrollPos + 1
+        var updatedScrollPos = root.scrollTop
+        root.scrollTop = initialScrollPos
+        scrollRoot = updatedScrollPos > initialScrollPos
+          ? root // spec-compliant browsers (like FF34 and IE11)
+          : document.body // naughty boys (like Chrome 39 and Safari 8)
+      }
+
+      // get scroll position
+      if (value == null) {
+        var el = sprintObj.get(0)
+        if (!el) return
+        if (el == window || el == document) {
+          el = scrollRoot
+        }
+        return el[method]
+      }
+
+      // set scroll position
+      return sprintObj.each(function() {
+        var el = this
+        if (el == window || el == document) {
+          el = scrollRoot
+        }
+        el[method] = value
+      })
+    }
+  }())
+
+  var selectAdjacentSiblings = function(sprintObj, direction, selector, until) {
+    var dom = []
+    var prop = direction + "ElementSibling"
+    sprintObj.each(function() {
+      var el = this
+      while (el = el[prop]) {
+        if (until && sprintObj.is(until, el)) break
+        if (selector && !sprintObj.is(selector, el)) continue
+        dom.push(el)
+      }
+    })
+    return Sprint(removeDuplicates(dom))
+  }
+
+  var selectImmediateAdjacentSibling = function(sprintObj, direction, selector) {
+    var prop = direction + "ElementSibling"
+    return sprintObj.map(function() {
+      var el = this[prop]
+      if (!el || (selector && !sprintObj.is(selector, el))) return
+      return el
+    }, false)
+  }
+
+  var selectElements = function(selector, context) {
+    context = context || document
+    // class, id, tag name or universal selector
+    if (/^[\#.]?[\w-]+$/.test(selector)) {
+      var firstChar = selector[0]
+      if (firstChar == ".") {
+        return toArray(context.getElementsByClassName(selector.slice(1)))
+      }
+      if (firstChar == "#") {
+        var el = context.getElementById(selector.slice(1))
+        return el ? [el] : []
+      }
+      if (selector == "body") {
+        return [document.body]
+      }
+      return toArray(context.getElementsByTagName(selector))
+    }
+    return toArray(context.querySelectorAll(selector))
+  }
+
+  var splitNamespaces = function(event) {
+    return sanitize(event.split("."))
+  }
+
+  var toArray = function(obj) {
+    var arr = []
+    var i = obj.length
+    while (i--) {
+      arr[i] = obj[i]
+    }
+    return arr
+  }
+
+  var wrap = (function() {
+    var callback = function(wrappingElement, variant) {
+      var wrap = Sprint(wrappingElement).clone(true).get(0)
+      var innerWrap = wrap
+      if (!wrap || this.nodeType > 1) return
+      while (innerWrap.firstChild) {
+        innerWrap = innerWrap.firstChild
+      }
+      if (variant == "inner") {
+        while (this.firstChild) {
+          innerWrap.appendChild(this.firstChild)
+        }
+        this.appendChild(wrap)
+      }
+      else {
+        var el = variant == "all" ? this.get(0) : this
+        var prt = el.parentNode
+        var next = el.nextSibling
+        variant == "all"
+          ? this.each(function() { innerWrap.appendChild(this) })
+          : innerWrap.appendChild(el)
+        prt.insertBefore(wrap, next)
+      }
+    }
+    return function(wrappingElement, variant) {
+      if (typeof wrappingElement == "function") {
+        this.each(function(i) {
+          Sprint(this)[variant == "inner" ? "wrapInner" : "wrap"](wrappingElement.call(this, i))
+        })
+      }
+      else {
+        variant == "all"
+          ? callback.call(this, wrappingElement, variant)
+          : this.each(function() { callback.call(this, wrappingElement, variant) })
+      }
+      return this
+    }
+  }())
+
+  var wrapMap = {
+    legend: {
+      intro: "<fieldset>",
+      outro: "</fieldset>"
+    },
+    area: {
+      intro: "<map>",
+      outro: "</map>"
+    },
+    param: {
+      intro: "<object>",
+      outro: "</object>"
+    },
+    thead: {
+      intro: "<table>",
+      outro: "</table>"
+    },
+    tr: {
+      intro: "<table><tbody>",
+      outro: "</tbody></table>"
+    },
+    col: {
+      intro: "<table><tbody></tbody><colgroup>",
+      outro: "</colgroup></table>"
+    },
+    td: {
+      intro: "<table><tbody><tr>",
+      outro: "</tr></tbody></table>"
+    }
+  };
+  // elements needing a construct already defined by other elements
+  ["tbody", "tfoot", "colgroup", "caption"].forEach(function(tag) {
+    wrapMap[tag] = wrapMap.thead
+  })
+  wrapMap.th = wrapMap.td
+
+  // constructor
+
+  var Init = function(selector, context) {
+    if (typeof selector == "string") {
+      // create DOM element
+      if (selector[0] == "<") {
+        this.dom = [createDOM(selector)]
+      }
+      // select DOM elements
+      else {
+        this.dom = context && context instanceof Init
+          ? context.find(selector).get()
+          : selectElements(selector, context)
+      }
+    }
+    else if (Array.isArray(selector)) {
+      this.dom = sanitize(selector)
+    }
+    else if (
+      selector instanceof NodeList ||
+      selector instanceof HTMLCollection
+    ) {
+      this.dom = toArray(selector)
+    }
+    else if (selector instanceof Init) {
+      return selector
+    }
+    else if (typeof selector == "function") {
+      return this.ready(selector)
+    }
+    else {
+      // assume DOM node
+      this.dom = selector ? [selector] : []
+    }
+    this.length = this.dom.length
+  }
+
+  Init.prototype = {
+    add: function(selector) {
+      var dom = this.get()
+      var objToAdd = Sprint(selector)
+      var domToAdd = objToAdd.get()
+      for (var i = 0; i < objToAdd.length; i++) {
+        dom.push(domToAdd[i])
+      }
+      return Sprint(removeDuplicates(dom))
+    },
+    addClass: function(className) {
+      return manipulateClass.call(this, "add", className)
+    },
+    after: function() {
+      insertHTML.call(this, "afterend", arguments)
+      return this
+    },
+    append: function() {
+      insertHTML.call(this, "beforeend", arguments)
+      return this
+    },
+    appendTo: function(target) {
+      return Sprint(insertHTML.call(Sprint(target), "beforeend", [this]))
+    },
+    attr: function(name, value) {
+      var isFunc = typeof value == "function"
+      if (typeof value == "string" || typeof value == "number" || isFunc) {
+        return this.each(function(i) {
+          if (this.nodeType > 1) return
+          this.setAttribute(
+            name, isFunc ? value.call(this, i, this.getAttribute(name)) : value
+          )
+        })
+      }
+      if (typeof name == "object") {
+        var attrNames = Object.keys(name)
+        var attrNamesLen = attrNames.length
+        return this.each(function() {
+          if (this.nodeType > 1) return
+          for (var i = 0; i < attrNamesLen; i++) {
+            var attribute = attrNames[i]
+            this.setAttribute(attribute, name[attribute])
+          }
+        })
+      }
+      var el = this.get(0)
+      if (!el || el.nodeType > 1) return
+      var attrValue = el.getAttribute(name)
+      if (attrValue == null) {
+        return undefined
+      }
+      if (!attrValue) {
+        return name
+      }
+      return attrValue
+    },
+    before: function() {
+      insertHTML.call(this, "beforebegin", arguments)
+      return this
+    },
+    children: function(selector) {
+      var dom = []
+      var self = this
+      this.each(function() {
+        if (this.nodeType > 1) return
+        var nodes = this.children
+        var nodesLen = nodes.length
+        for (var i = 0; i < nodesLen; i++) {
+          var node = nodes[i]
+          if (!selector || self.is(selector, node)) {
+            dom.push(node)
+          }
+        }
+      })
+      return Sprint(dom)
+    },
+    clone: function(withEvents) {
+      return this.map(function() {
+        if (!this) return
+        var clone = this.cloneNode(true)
+        withEvents && duplicateEventListeners(this, clone)
+        return clone
+      }, false)
+    },
+    closest: function(selector, context) {
+      return findAncestors.call(this, false, false, true, selector, context)
+    },
+    css: function(property, value) {
+      var valueType = typeof value
+      var isString = valueType == "string"
+
+      // set
+      if (isString || valueType == "number") {
+        var isRelativeValue = isString && /=/.test(value)
+        if (isRelativeValue) {
+          var relativeValue = parseInt(value[0] + value.slice(2))
+        }
+        return this.each(function() {
+          if (this.nodeType > 1) return
+          if (isRelativeValue) {
+            var current = parseInt(getComputedStyle(this).getPropertyValue(property))
+            var result = current + relativeValue
+          }
+          this.style[property] = addPx(property, isRelativeValue ? result : value)
+        })
+      }
+      // set
+      if (valueType == "function") {
+        return this.each(function(index) {
+          if (this.nodeType > 1) return
+          var oldValue = getComputedStyle(this).getPropertyValue(property)
+          this.style[property] = value.call(this, index, oldValue)
+        })
+      }
+      // read
+      if (typeof property == "string") {
+        var el = this.get(0)
+        if (!el || el.nodeType > 1) return
+        return getComputedStyle(el).getPropertyValue(property)
+      }
+      // read
+      if (Array.isArray(property)) {
+        var el = this.get(0)
+        if (!el || el.nodeType > 1) return
+        var o = {}
+        var styles = getComputedStyle(el)
+        var propertyLen = property.length
+        for (var i = 0; i < propertyLen; i++) {
+          var prop = property[i]
+          o[prop] = styles.getPropertyValue(prop)
+        }
+        return o
+      }
+      // set
+      var properties = Object.keys(property)
+      var propertiesLen = properties.length
+      return this.each(function() {
+        if (this.nodeType > 1) return
+        for (var i = 0; i < propertiesLen; i++) {
+          var prop = properties[i]
+          this.style[prop] = addPx(prop, property[prop])
+        }
+      })
+    },
+    detach: function() {
+      return this.map(function() {
+        var parent = this.parentElement
+        if (!parent) return
+        parent.removeChild(this)
+        return this
+      }, false)
+    },
+    data: function(name, value) {
+      if (value === undefined) {
+        var el = this.get(0)
+        if (!('sprint_data' in el)) el.sprint_data = {}
+        return el.sprint_data[name]
+      } else {
+        this.get().forEach(function(el) {
+          if (!('sprint_data' in el)) el.sprint_data = {}
+          el.sprint_data[name] = value
+        })
+      }
+
+      return this
+    },
+    each: function(callback) {
+      // callback(index, element) where element == this
+      var dom = this.dom
+      var len = this.length
+      for (var i = 0; i < len; i++) {
+        var node = dom[i]
+        callback.call(node, i, node)
+      }
+      return this
+    },
+    empty: function() {
+      return this.each(function() {
+        this.innerHTML = ""
+      })
+    },
+    eq: function(index) {
+      return Sprint(this.get(index))
+    },
+    filter: function(selector) {
+      var isFunc = typeof selector == "function"
+      var self = this
+      return this.map(function(i) {
+        if ( this.nodeType > 1
+          || (!isFunc && !self.is(selector, this))
+          || (isFunc && !selector.call(this, i, this))
+        ) return
+        return this
+      }, false)
+    },
+    find: function(selector) {
+      // .find(selector)
+      if (typeof selector == "string") {
+        var dom = []
+        this.each(function() {
+          if (this.nodeType > 1) return
+          var elements = selectElements(selector, this)
+          var elementsLen = elements.length
+          for (var i = 0; i < elementsLen; i++) {
+            dom.push(elements[i])
+          }
+        })
+        return Sprint(removeDuplicates(dom))
+      }
+
+      // .find(element)
+      var elementsToFind = selector.nodeType ? [selector] : selector.get()
+      var elementsToFindLen = elementsToFind.length
+      var elementsFound = []
+      var elementsFoundLen = 0
+
+      for (var i = 0; i < this.length; i++) {
+        var el = this.get(i)
+        if (el.nodeType > 1) continue
+        // check if each element in `this` contains the elements to find
+        for (var j = 0; j < elementsToFindLen; j++) {
+          var elementToFind = elementsToFind[j]
+          if (!el.contains(elementToFind)) continue
+          elementsFound[elementsFoundLen++] = elementToFind
+          if (elementsFoundLen < elementsToFindLen) continue
+          // everything has been found, return results
+          return Sprint(elementsFound)
+        }
+      }
+
+      // some elements in elementsToFind weren't descendants of `this`
+      return Sprint(elementsFound)
+    },
+    first: function() {
+      return this.eq(0)
+    },
+    get: function(index) {
+      if (index == null) {
+        return this.dom
+      }
+      if (index < 0) {
+        index += this.length
+      }
+      return this.dom[index]
+    },
+    has: function(selector) {
+      // .has(selector)
+      if (typeof selector == "string") {
+        return this.map(function() {
+          if (this.nodeType > 1 || !selectElements(selector, this)[0]) return
+          return this
+        }, false)
+      }
+
+      // .has(contained)
+      var result = []
+      var i = this.length
+      while (i--) {
+        var el = this.get(i)
+        if (!el.contains(selector)) continue
+        result.push(el)
+        break
+      }
+      return Sprint(result)
+    },
+    hasClass: function(name) {
+      var i = this.length
+      while (i--) {
+        var el = this.get(i)
+        if (el.nodeType > 1) return
+        if (el.classList.contains(name)) {
+          return true
+        }
+      }
+      return false
+    },
+    height: function(value) {
+      return getSetDimension(this, "height", value)
+    },
+    html: function(htmlString) {
+      if (htmlString == null) {
+        var el = this.get(0)
+        if (!el) return
+        return el.innerHTML
+      }
+      if (typeof htmlString == "function") {
+        return this.each(function(i) {
+          var content = htmlString.call(this, i, this.innerHTML)
+          Sprint(this).html(content)
+        })
+      }
+      return this.each(function() {
+        this.innerHTML = htmlString
+      })
+    },
+    index: function(el) {
+      if (!this.length) return
+      var toFind
+      var sprintElements
+      if (!el) {
+        toFind = this.get(0)
+        sprintElements = this.first().parent().children()
+      }
+      else if (typeof el == "string") {
+        toFind = this.get(0)
+        sprintElements = Sprint(el)
+      }
+      else {
+        toFind = el instanceof Init ? el.get(0) : el
+        sprintElements = this
+      }
+      var elements = sprintElements.get()
+      var i = elements.length
+      while (i--) {
+        if (elements[i] == toFind) {
+          return i
+        }
+      }
+      return -1
+    },
+    insertAfter: function(target) {
+      Sprint(target).after(this)
+      return this
+    },
+    insertBefore: function(target) {
+      Sprint(target).before(this)
+      return this
+    },
+    is: function(selector, element) {
+      // element is undocumented, internal-use only.
+      // It gives better perfs as it prevents the creation of many objects in internal methods.
+      var set = element ? [element] : this.get()
+      var setLen = set.length
+
+      if (typeof selector == "string") {
+        for (var i = 0; i < setLen; i++) {
+          var el = set[i]
+          if (el.nodeType > 1) continue
+          if (el[matches](selector)) {
+            return true
+          }
+        }
+        return false
+      }
+      if (typeof selector == "object") {
+        // Sprint object or DOM element(s)
+        var obj
+        if (selector instanceof Init) {
+          obj = selector.get()
+        }
+        else {
+          obj = selector.length ? selector : [selector]
+        }
+        var objLen = obj.length
+        for (var i = 0; i < setLen; i++) {
+          for (var j = 0; j < objLen; j++) {
+            if (set[i] === obj[j]) {
+              return true
+            }
+          }
+        }
+        return false
+      }
+      if (typeof selector == "function") {
+        for (var i = 0; i < setLen; i++) {
+          if (selector.call(this, i, this)) {
+            return true
+          }
+        }
+        return false
+      }
+    },
+    last: function() {
+      return this.eq(-1)
+    },
+    map: function(callback, flattenArrays) {
+      /*
+       * flattenArrays (bool, true by default) is for internal usage only (although it might be
+       * interesting to document it publicly).
+       * Many methods rely on map(), thus being able to avoid the unnecessary Array.isArray() check
+       * on each element is a significant perf boost.
+       */
+      if (flattenArrays == null) {
+        flattenArrays = true
+      }
+
+      var dom = this.get()
+      var len = this.length
+      var values = []
+
+      for (var i = 0; i < len; i++) {
+        var el = dom[i]
+        var val = callback.call(el, i, el)
+
+        if (flattenArrays && Array.isArray(val)) {
+          var valLen = val.length
+          for (var j = 0; j < valLen; j++) {
+            values.push(val[j])
+          }
+          continue
+        }
+
+        values.push(val)
+      }
+
+      return Sprint(values)
+    },
+    next: function(selector) {
+      return selectImmediateAdjacentSibling(this, "next", selector)
+    },
+    nextAll: function(selector) {
+      return selectAdjacentSiblings(this, "next", selector)
+    },
+    nextUntil: function(selector, filter) {
+      return selectAdjacentSiblings(this, "next", filter, selector)
+    },
+    not: function(selector) {
+      var isFunc = typeof selector == "function"
+      var self = this
+      return this.map(function(i) {
+        if (isFunc) {
+          if (selector.call(this, i, this)) return
+        }
+        else {
+          if (self.is(selector, this)) return
+        }
+        return this
+      }, false)
+    },
+    off: function(events, handler) {
+      if (typeof events == "object") {
+        Object.keys(events).forEach(function(event) {
+          this.off(event, events[event])
+        }, this)
+        return this
+      }
+      if (events) {
+        events = events.trim().split(" ")
+      }
+      return this.each(function() {
+        if (!getEvents(this)) return
+        if (events) {
+          events.forEach(removeMatchedEvents(this, handler))
+          return
+        }
+        Object.keys(getEvents(this)).forEach(removeEvent(this))
+      })
+    },
+    offset: function(coordinates) {
+      if (!coordinates) {
+        var el = this.get(0)
+        if (!el || el.nodeType > 1) return
+        var pos = el.getBoundingClientRect()
+        return {
+          top: pos.top + window.pageYOffset,
+          left: pos.left + window.pageXOffset
+        }
+      }
+      if (typeof coordinates == "object") {
+        return this.each(function() {
+          if (this.nodeType > 1) return
+          var $this = Sprint(this)
+          $this.css("position") == "static"
+            ? $this.css("position", "relative")
+            : $this.css({
+              top: 0,
+              left: 0
+            })
+          var pos = $this.offset()
+          $this.css({
+            top: coordinates.top - pos.top + "px",
+            left: coordinates.left - pos.left + "px"
+          })
+        })
+      }
+      if (typeof coordinates == "function") {
+        return this.each(function(i) {
+          var $this = Sprint(this)
+          var posObj = coordinates.call(this, i, $this.offset())
+          $this.offset(posObj)
+        })
+      }
+    },
+    offsetParent: function() {
+      var dom = []
+      this.each(function() {
+        if (this.nodeType > 1) return
+        var prt = this
+        while (prt != root) {
+          prt = prt.parentNode
+          var pos = getComputedStyle(prt).getPropertyValue("position")
+          if (!pos) break
+          if (pos != "static") {
+            dom.push(prt)
+            return
+          }
+        }
+        dom.push(root)
+      })
+      return Sprint(dom)
+    },
+    on: function(events, handler) {
+      // .on(events, handler)
+      if (handler) {
+        var eventsArr = events.trim().split(" ")
+
+        return this.each(function() {
+          if (!getEvents(this)) {
+            this.sprintEventListeners = {}
+          }
+          eventsArr.forEach(function(event) {
+            if (!getEvents(this)[event]) {
+              getEvents(this)[event] = []
+            }
+            getEvents(this)[event].push(handler)
+
+            // Ensure we add both the standard event (eg: "click") and the full event
+            // (eg: "click.foo") in order to be able to trigger them manually and programmatically.
+            this.addEventListener(event, handler)
+            if (!isNamespaced(event)) return
+            this.addEventListener(getEventFromNamespace(event), handler)
+          }, this)
+        })
+      }
+
+      // .on({ event: handler })
+      Object.keys(events).forEach(function(event) {
+        this.on(event, events[event])
+      }, this)
+      return this
+    },
+    parent: function(selector) {
+      return findAncestors.call(this, true, true, false, selector)
+    },
+    parents: function(selector) {
+      /* Differences with jQuery:
+       * 1. $("html").parent() and $("html").parents() return an empty set.
+       * 2. The returned set won't be in reverse order.
+       */
+      return findAncestors.call(this, true, false, false, selector)
+    },
+    position: function() {
+      var pos = {
+        first: this.offset(),
+        prt: this.parent().offset()
+      }
+      if (!pos.first) return
+      return {
+        top: pos.first.top - pos.prt.top,
+        left: pos.first.left - pos.prt.left
+      }
+    },
+    prop: function(propertyName, value) {
+      if (typeof propertyName == "object") {
+        var props = Object.keys(propertyName)
+        var propsLen = props.length
+        return this.each(function() {
+          for (var i = 0; i < propsLen; i++) {
+            var prop = props[i]
+            this[prop] = propertyName[prop]
+          }
+        })
+      }
+      if (value == null) {
+        var el = this.get(0)
+        if (!el) return
+        return el[propertyName]
+      }
+      var isFunc = typeof value == "function"
+      return this.each(function(i) {
+        this[propertyName] = isFunc ? value.call(this, i, this[propertyName]) : value
+      })
+    },
+    prepend: function() {
+      insertHTML.call(this, "afterbegin", arguments)
+      return this
+    },
+    prependTo: function(target) {
+      return Sprint(insertHTML.call(Sprint(target), "afterbegin", [this]))
+    },
+    prev: function(selector) {
+      return selectImmediateAdjacentSibling(this, "previous", selector)
+    },
+    prevAll: function(selector) {
+      return selectAdjacentSiblings(this, "previous", selector)
+    },
+    prevUntil: function(selector, filter) {
+      return selectAdjacentSiblings(this, "previous", filter, selector)
+    },
+    ready: function(handler) {
+      this.dom = [document]
+      this.length = 1
+      return this.on("DOMContentLoaded", handler)
+    },
+    remove: function(selector) {
+      var self = this
+      return this.each(function() {
+        var parent = this.parentElement
+        if (!parent) return
+        if (!selector || self.is(selector, this)) {
+          parent.removeChild(this)
+        }
+      })
+    },
+    removeAttr: function(attributeName) {
+      if (attributeName) {
+        var attributes = attributeName.trim().split(" ")
+        var attributesLen = attributes.length
+        this.each(function() {
+          if (this.nodeType > 1) return
+          for (var i = 0; i < attributesLen; i++) {
+            this.removeAttribute(attributes[i])
+          }
+        })
+      }
+      return this
+    },
+    removeClass: function(className) {
+      return manipulateClass.call(this, "remove", className)
+    },
+    removeProp: function(propertyName) {
+      return this.each(function() {
+        this[propertyName] = undefined
+      })
+    },
+    replaceAll: function(target) {
+      Sprint(target).replaceWith(this)
+      return this
+    },
+    replaceWith: function(newContent) {
+      if (typeof newContent == "function") {
+        return this.each(function(i) {
+          Sprint(this).replaceWith(newContent.call(this, i, this))
+        })
+      }
+      return this.before(newContent).remove()
+    },
+    scrollLeft: function(value) {
+      return scroll(this, "scrollLeft", value)
+    },
+    scrollTop: function(value) {
+      return scroll(this, "scrollTop", value)
+    },
+    siblings: function(selector) {
+      var siblings = []
+      var self = this
+      this.each(function(i, el) {
+        Sprint(this).parent().children().each(function() {
+          if (this == el || (selector && !self.is(selector, this))) return
+          siblings.push(this)
+        })
+      })
+      return Sprint(siblings)
+    },
+    size: function() {
+      return this.length
+    },
+    slice: function(start, end) {
+      var dom = this.get()
+      var range = []
+      var i = start >= 0 ? start : start + this.length
+      var l = this.length
+      if (end < 0) {
+        l += end
+      }
+      else if (end >= 0) {
+        l = end > this.length ? this.length : end
+      }
+      for (; i < l; i++) {
+        range.push(dom[i])
+      }
+      return Sprint(range)
+    },
+    text: function(content) {
+      if (content == null) {
+        var textContents = []
+        this.each(function() {
+          textContents.push(this.textContent)
+        })
+        return textContents.join("")
+      }
+      var isFunc = typeof content == "function"
+      return this.each(function(i) {
+        this.textContent = isFunc ? content.call(this, i, this.textContent) : content
+      })
+    },
+    toggleClass: function(className, bool) {
+      return manipulateClass.call(this, "toggle", className, bool)
+    },
+    trigger: function(event) {
+      // IE polyfill
+      if (!window.CustomEvent || typeof window.CustomEvent !== "function") {
+        var CustomEvent = function(event, params) {
+          var evt
+          params = params || {
+            bubbles: false,
+            cancelable: false,
+            detail: undefined
+          }
+          evt = document.createEvent("CustomEvent")
+          evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail)
+          return evt
+        }
+        CustomEvent.prototype = window.Event.prototype
+        window.CustomEvent = CustomEvent
+      }
+      return this.each(function() {
+        getEventsToRemove(this, event).forEach(function(matchedEvent) {
+          this.dispatchEvent(new CustomEvent(matchedEvent, {
+            bubbles: true,
+            cancelable: true
+          }))
+        }, this)
+      })
+    },
+    unwrap: function() {
+      this.parent().each(function() {
+        if (this == document.body || this == root) return
+        Sprint(this).replaceWith(this.childNodes)
+      })
+      return this
+    },
+    val: function(value) {
+      if (value == null) {
+        var el = this.get(0)
+        if (!el) return
+        if (el.multiple) {
+          var values = []
+          this.first().children(":checked").each(function() {
+            values.push(this.value)
+          })
+          return values
+        }
+        return el.value
+      }
+      if (Array.isArray(value)) {
+        var self = this
+        return this.each(function() {
+          if (this.multiple) {
+            self.children().each(function() {
+              this.selected = inArray(this.value, value)
+            })
+            return
+          }
+          this.checked = inArray(this.value, value)
+        })
+      }
+      if (typeof value == "function") {
+        return this.each(function(i) {
+          Sprint(this).val(value.call(this, i, this.value))
+        })
+      }
+      return this.each(function() {
+        this.value = value
+      })
+    },
+    width: function(value) {
+      return getSetDimension(this, "width", value)
+    },
+    wrap: function(wrappingElement) {
+      return wrap.call(this, wrappingElement)
+    },
+    wrapAll: function(wrappingElement) {
+      return wrap.call(this, wrappingElement, "all")
+    },
+    wrapInner: function(wrappingElement) {
+      return wrap.call(this, wrappingElement, "inner")
+    }
+  }
+
+  // public
+
+  var Sprint = function(selector, context) {
+    return new Init(selector, context)
+  }
+
+  if (typeof define === "function" && define.amd) {
+    define(function() {
+      return Sprint
+    })
+  } else if (typeof module !== "undefined" && module.exports) {
+    module.exports = Sprint
+  } else {
+    this.Sprint = Sprint
+
+    if (this.$ == null) {
+      this.$ = Sprint
+    }
+  }
+}.call(this));

--- a/modules/sprint.js
+++ b/modules/sprint.js
@@ -795,6 +795,7 @@
     },
     data: function(name, value) {
       if (value === undefined) {
+        if (this.length == 0) return null
         var el = this.get(0)
         if (!('sprint_data' in el)) el.sprint_data = {}
         return el.sprint_data[name]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "jquery": "^2.2.4",
     "octicons": "^3.3.0",
     "pikaday": "^1.4.0",
-    "sigma": "^1.0.3"
+    "sigma": "^1.0.3",
+    "sprint-js": "^0.1.0"
   },
   "scripts": {
     "test": "mocha",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "license": "MIT",
   "dependencies": {
     "argv-split": "^1.0.0",
-    "cash-dom": "^1.3.0",
     "gemini-scrollbar": "^1.2.9",
+    "jquery": "^2.2.4",
     "octicons": "^3.3.0",
     "pikaday": "^1.4.0",
     "sigma": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -16,11 +16,9 @@
   "dependencies": {
     "argv-split": "^1.0.0",
     "gemini-scrollbar": "^1.2.9",
-    "jquery": "^2.2.4",
     "octicons": "^3.3.0",
     "pikaday": "^1.4.0",
-    "sigma": "^1.0.3",
-    "sprint-js": "^0.1.0"
+    "sigma": "^1.0.3"
   },
   "scripts": {
     "test": "mocha",

--- a/view/index.js
+++ b/view/index.js
@@ -2112,6 +2112,6 @@ $(window).on('resize', function() {
     if (win.isMaximized() || win.isMinimized() || win.isFullScreen()) return
 
     setting
-    .set('window.width', $('body').width())
-    .set('window.height', $('body').height())
+    .set('window.width', Math.round($('body').width()))
+    .set('window.height', Math.round($('body').height()))
 })

--- a/view/index.js
+++ b/view/index.js
@@ -516,7 +516,7 @@ function prepareConsole() {
 
         var $input = $(this).find('input')
         if ($input.val().trim() == '') return
-        $input.blur()
+        $input.get(0).blur()
 
         var command = gtp.parseCommand($input.val())
         sendGTPCommand(command)
@@ -1645,7 +1645,7 @@ function sendGTPCommand(command, ignoreBlocked, callback) {
     var controller = getEngineController()
     var $container = $('#console .inner')
     var $oldform = $container.find('form:last-child')
-    var $form = $oldform.clone(true, true)
+    var $form = $oldform.clone(true)
     var $pre = $('<pre/>').text(' ')
 
     $form.find('input').val('')

--- a/view/index.js
+++ b/view/index.js
@@ -245,10 +245,10 @@ function setBoard(board) {
 
     board.ghosts.forEach(function(x) {
         var v = x[0], s = x[1], type = x[2]
-        var li = $('#goban .pos_' + v.join('-'))
+        var $li = $('#goban .pos_' + v.join('-'))
 
-        if (type == 'child') li.addClass('ghost_' + s)
-        else if (type == 'sibling') li.addClass('siblingghost_' + s)
+        if (type == 'child') $li.addClass('ghost_' + s)
+        else if (type == 'sibling') $li.addClass('siblingghost_' + s)
     })
 
     // Add lines
@@ -268,7 +268,7 @@ function setBoard(board) {
 }
 
 function getScoringMethod() {
-    return $('#score .tabs .territory')[0].hasClass('current') ? 'territory' : 'area'
+    return $('#score .tabs .territory').hasClass('current') ? 'territory' : 'area'
 }
 
 function setScoringMethod(method) {
@@ -282,14 +282,14 @@ function setScoringMethod(method) {
     // Update UI
 
     for (var sign = -1; sign <= 1; sign += 2) {
-        var tr = $('#score tbody tr' + (sign < 0 ? ':last-child' : ''))[0]
-        var tds = tr.find('td')
+        var $tr = $('#score tbody tr' + (sign < 0 ? ':last-child' : ''))
+        var $tds = $tr.find('td')
 
-        tds[4].text(0)
+        $tds.eq(4).text(0)
 
         for (var i = 0; i <= 3; i++) {
-            if (tds[i].hasClass('disabled') || isNaN(+tds[i].text())) continue
-            tds[4].text(+tds[4].text() + +tds[i].text())
+            if ($tds.eq(i).hasClass('disabled') || isNaN(+$tds.eq(i).text())) continue
+            $tds.eq(4).text(+$tds.eq(4).text() + +$tds.eq(i).text())
         }
     }
 
@@ -1353,7 +1353,7 @@ function vertexClicked(vertex, event) {
                 for (var y = 0; y < board.height; y++) {
                     var z = i == 0 ? x : y
                     if (Math.abs(z - vertex[i]) < Math.abs(z - nextVertex[i]))
-                        $('#goban .pos_' + x + '-' + y)[0].addClass('paint_1')
+                        $('#goban .pos_' + x + '-' + y).addClass('paint_1')
                 }
             }
         }

--- a/view/index.js
+++ b/view/index.js
@@ -285,7 +285,7 @@ function setScoringMethod(method) {
 
     for (var sign = -1; sign <= 1; sign += 2) {
         var tr = $('#score tbody tr' + (sign < 0 ? ':last-child' : ''))[0]
-        var tds = tr.children('td')
+        var tds = tr.find('td')
 
         tds[4].text(0)
 
@@ -606,13 +606,13 @@ function prepareGameInfo() {
             $(this).data('engineindex', i)
 
             if (engine) {
-                var els = $('#info').children('section .menu')
+                var els = $('#info').find('section .menu')
                 var other = els[0] == this ? els[1] : els[0]
                 if (other) selectEngine.call(other, null, -1)
 
                 $(this).addClass('active')
             } else {
-                $('#info').children('section .menu')
+                $('#info').find('section .menu')
                 .removeClass('active')
             }
         }
@@ -634,7 +634,7 @@ function prepareGameInfo() {
             return x.length == 3
         })
 
-        $(pikaday.el).children('.pika-button').get().forEach(function(el) {
+        $(pikaday.el).find('.pika-button').get().forEach(function(el) {
             var year = +$(el).attr('data-pika-year')
             var month = +$(el).attr('data-pika-month')
             var day = +$(el).attr('data-pika-day')

--- a/view/index.js
+++ b/view/index.js
@@ -1203,8 +1203,8 @@ function useTool(vertex, event) {
 
         // Update SGF
 
-        $('#goban .row li').forEach(function(li) {
-            var v = li.data('vertex')
+        $('#goban .row li').get().forEach(function(li) {
+            var v = $(li).data('vertex')
             if (!(v in board.markups)) return
 
             var id = dictionary[board.markups[v][0]]
@@ -1450,25 +1450,25 @@ function updateCommentText() {
 function updateAreaMap(useEstimateMap) {
     var board = getBoard().clone()
 
-    $('#goban .row li.dead').forEach(function(li) {
-        if (li.hasClass('sign_1')) board.captures['-1']++
-        else if (li.hasClass('sign_-1')) board.captures['1']++
+    $('#goban .row li.dead').get().forEach(function(li) {
+        if ($(li).hasClass('sign_1')) board.captures['-1']++
+        else if ($(li).hasClass('sign_-1')) board.captures['1']++
 
-        board.arrangement[li.data('vertex')] = 0
+        board.arrangement[$(li).data('vertex')] = 0
     })
 
     var map = useEstimateMap ? board.getAreaEstimateMap() : board.getAreaMap()
 
-    $('#goban .row li').forEach(function(li) {
-        li.removeClass('area_-1').removeClass('area_0').removeClass('area_1')
-            .addClass('area_' + map[li.data('vertex')])
+    $('#goban .row li').get().forEach(function(li) {
+        $(li).removeClass('area_-1').removeClass('area_0').removeClass('area_1')
+            .addClass('area_' + map[$(li).data('vertex')])
     })
 
     if (!useEstimateMap) {
-        var falsedead = $('#goban .row li.area_-1.sign_-1.dead, #goban .row li.area_1.sign_1.dead')
+        var $falsedead = $('#goban .row li.area_-1.sign_-1.dead, #goban .row li.area_1.sign_1.dead')
 
-        if (falsedead.length > 0) {
-            falsedead.removeClass('dead')
+        if ($falsedead.length > 0) {
+            $falsedead.removeClass('dead')
             return updateAreaMap()
         }
     }
@@ -1594,7 +1594,7 @@ function commitScore() {
 function commitPreferences() {
     // Save general preferences
 
-    $('#preferences input[type="checkbox"]').forEach(function(el) {
+    $('#preferences input[type="checkbox"]').get().forEach(function(el) {
         setting.set(el.name, el.checked)
     })
 
@@ -1606,13 +1606,13 @@ function commitPreferences() {
 
     setting.clearEngines()
 
-    $('#preferences .engines-list li').forEach(function(li) {
-        var nameinput = li.find('h3 input')
+    $('#preferences .engines-list li').get().forEach(function(li) {
+        var nameinput = $(li).find('h3 input')
 
         setting.addEngine(
             nameinput.value.trim() == '' ? nameinput.placeholder : nameinput.value,
-            li.find('h3 + p input').value,
-            li.find('h3 + p + p input').value
+            $(li).find('h3 + p input').value,
+            $(li).find('h3 + p + p input').value
         )
     })
 

--- a/view/index.js
+++ b/view/index.js
@@ -378,12 +378,12 @@ function loadSettings() {
     $('#goban').toggleClass('siblings', setting.get('view.show_siblings'))
 
     if (setting.get('view.show_leftsidebar')) {
-        document.body.addClass('leftsidebar')
+        $('body').addClass('leftsidebar')
         setLeftSidebarWidth(setting.get('view.leftsidebar_width'))
     }
 
     if (setting.get('view.show_graph') || setting.get('view.show_comments')) {
-        document.body.addClass('sidebar')
+        $('body').addClass('sidebar')
         setSidebarArrangement(setting.get('view.show_graph'), setting.get('view.show_comments'))
         setSidebarWidth(setting.get('view.sidebar_width'))
     }
@@ -502,7 +502,7 @@ function prepareDragDropFiles() {
     Element.NativeEvents.dragstart = 2
     Element.NativeEvents.drop = 2
 
-    document.body.on('dragover', function(e) {
+    $('body').on('dragover', function(e) {
         e.preventDefault()
     }).on('drop', function(e) {
         e.preventDefault()
@@ -695,7 +695,7 @@ function prepareGameInfo() {
     dateInput.data('pikaday', pikaday)
     pikaday.hide()
 
-    document.body.grab(pikaday.el).on('click', function(e) {
+    $('body').grab(pikaday.el).on('click', function(e) {
         if (pikaday.isVisible()
         && document.activeElement != dateInput
         && e.target != dateInput
@@ -703,7 +703,7 @@ function prepareGameInfo() {
             pikaday.hide()
     })
 
-    window.on('resize', function() { adjustPosition(pikaday) })
+    $(window).on('resize', function() { adjustPosition(pikaday) })
 
     dateInput.on('focus', function() {
         pikaday.show()
@@ -2086,12 +2086,12 @@ function undoBoard() {
  * Main events
  */
 
-document.on('keydown', function(e) {
+$(document).on('keydown', function(e) {
     if (e.code == 27) {
         // Escape key
         closeDrawers()
     }
-}).on('domready', function() {
+}).ready(function() {
     loadSettings()
     loadEngines()
     prepareDragDropFiles()
@@ -2108,7 +2108,7 @@ document.on('keydown', function(e) {
     })
 })
 
-window.on('resize', function() {
+$(window).on('resize', function() {
     resizeBoard()
 }).on('beforeunload', function(e) {
     if (!askForSave()) {
@@ -2121,6 +2121,7 @@ window.on('resize', function() {
     var win = remote.getCurrentWindow()
     if (win.isMaximized() || win.isMinimized() || win.isFullScreen()) return
 
-    var size = document.body.getSize()
-    setting.set('window.width', size.x).set('window.height', size.y)
+    setting
+    .set('window.width', $('body').width())
+    .set('window.height', $('body').height())
 })

--- a/view/index.js
+++ b/view/index.js
@@ -390,15 +390,16 @@ function loadSettings() {
 
 function prepareEditTools() {
     $('#edit ul a').on('click', function() {
-        var $img = $(this).find('img')
+        var $a = $(this)
+        var $img = $a.find('img')
 
-        if (!$(this).parent().hasClass('selected')) {
+        if (!$a.parent().hasClass('selected')) {
             $('#edit .selected').removeClass('selected')
-            $(this).parent().addClass('selected')
-        } else if ($(this).parent().hasClass('stone-tool')) {
+            $a.parent().addClass('selected')
+        } else if ($a.parent().hasClass('stone-tool')) {
             var black = $img.attr('src').indexOf('_1') >= 0
             $img.attr('src', black ? '../img/edit/stone_-1.svg' : '../img/edit/stone_1.svg')
-        } else if ($(this).parent().hasClass('line-tool')) {
+        } else if ($a.parent().hasClass('line-tool')) {
             var line = $img.attr('src').indexOf('line') >= 0
             $img.attr('src', line ? '../img/edit/arrow.svg' : '../img/edit/line.svg')
         }
@@ -508,21 +509,21 @@ function prepareConsole() {
     $('#console form').on('submit', function(e) {
         e.preventDefault()
 
-        var input = $(this).find('input')
-        if (input.value.trim() == '') return
-        input.blur()
+        var $input = $(this).find('input')
+        if ($input.val().trim() == '') return
+        $input.blur()
 
-        var command = gtp.parseCommand(input.value)
+        var command = gtp.parseCommand($input.val())
         sendGTPCommand(command)
     })
 
     $('#console form input').on('keydown', function(e) {
         if ([40, 38, 9].indexOf(e.code) != -1) e.preventDefault()
-        var inputs = $('#console form input')
+        var $inputs = $('#console form input')
 
-        if ($(this).data('index') == null) $(this).data('index', inputs.indexOf(this))
+        if ($(this).data('index') == null) $(this).data('index', $inputs.get().indexOf(this))
         var i = $(this).data('index')
-        var length = inputs.length
+        var length = $inputs.length
 
         if ([38, 40].indexOf(e.code) != -1) {
             if (e.code == 38) {
@@ -533,11 +534,12 @@ function prepareConsole() {
                 i = Math.min(i + 1, length - 1)
             }
 
-            this.value = i == length - 1 ? '' : inputs[i].value
-            $(this).data('index', i)
+            $(this)
+            .val(i == length - 1 ? '' : $inputs.eq(i).val())
+            .data('index', i)
         } else if (e.code == 9) {
             // Tab
-            var tokens = this.value.split(' ')
+            var tokens = $(this).val().split(' ')
             var commands = getEngineCommands()
             if (!commands) return
 
@@ -573,23 +575,26 @@ function prepareGameInfo() {
     })
 
     $('#info .currentplayer').on('click', function() {
-        var data = $('#info section input[type="text"]').map(function(el) {
-            return el.val()
+        var data = $('#info section input[type="text"]').get().map(function(el) {
+            return $(el).val()
         })
 
-        $('#info section input[name="rank_1"]').eq(0).val(data[3])
-        $('#info section input[name="rank_-1"]').eq(0).val(data[0])
-        $('#info section input[name="name_1"]').eq(0).val(data[2])
-        $('#info section input[name="name_-1"]').eq(0).val(data[1])
+        $('#info section input[name="rank_1"]').val(data[3])
+        $('#info section input[name="rank_-1"]').val(data[0])
+        $('#info section input[name="name_1"]').val(data[2])
+        $('#info section input[name="name_-1"]').val(data[1])
 
-        data = $('#info section .menu').map(function(el) {
-            return [el.hasClass('active'), el.data('engineindex')]
+        data = $('#info section .menu').get().map(function(el) {
+            return [$(el).hasClass('active'), $(el).data('engineindex')]
         })
 
-        $('#info section .menu')[0].toggleClass('active', data[1][0])
-        $('#info section .menu')[0].data('engineindex', data[1][1])
-        $('#info section .menu')[1].toggleClass('active', data[0][0])
-        $('#info section .menu')[1].data('engineindex', data[0][1])
+        $('#info section .menu').eq(0)
+        .toggleClass('active', data[1][0])
+        .data('engineindex', data[1][1])
+
+        $('#info section .menu').eq(1)
+        .toggleClass('active', data[0][0])
+        .data('engineindex', data[0][1])
     })
 
     $('#info section img.menu').on('click', function() {
@@ -620,7 +625,7 @@ function prepareGameInfo() {
 
     // Prepare date input
 
-    var $dateInput = $('#info input[name="date"]').eq(0)
+    var $dateInput = $('#info input[name="date"]')
     var adjustPosition = function(pikaday) {
         $(pikaday.el)
         .css('position', 'absolute')
@@ -690,21 +695,24 @@ function prepareGameInfo() {
     $('body').append(pikaday.el).on('click', function(e) {
         if (pikaday.isVisible()
         && document.activeElement != $dateInput.get(0)
-        && e.target != $dateInput.get(0)
-        && e.target.parents('.pika-lendar').length == 0)
+        && e.originalEvent.target != $dateInput.get(0)
+        && e.originalEvent.target.parents('.pika-lendar').length == 0)
             pikaday.hide()
     })
 
     $(window).on('resize', function() { adjustPosition(pikaday) })
 
-    $dateInput.on('focus', function() {
+    $dateInput
+    .on('focus', function() {
         pikaday.show()
-    }).on('blur', function() {
+    })
+    .on('blur', function() {
         setTimeout(function() {
             if (document.activeElement.parents('.pika-lendar').length == 0)
                 pikaday.hide()
         }, 50)
-    }).on('input', function() {
+    })
+    .on('input', function() {
         markDates(pikaday)
     })
 
@@ -713,20 +721,20 @@ function prepareGameInfo() {
     $('#info input[name^="size-"]').attr('placeholder', setting.get('game.default_board_size'))
 
     $('#info input[name="size-width"]').on('focus', function() {
-        $(this).data('link', this.value == $(this).parent().next('input[name="size-height"]').value)
+        $(this).data('link', this.value == $(this).parent().nextAll('input[name="size-height"]').val())
     }).on('input', function() {
         if (!$(this).data('link')) return
-        $(this).parent().next('input[name="size-height"]').value = this.value
+        $(this).parent().nextAll('input[name="size-height"]').val(this.value)
     })
 
     $('#info span.size-swap').on('click', function() {
         if ($('#info').hasClass('disabled')) return
 
-        var widthInput = $('#info input[name="size-width"]')[0]
-        var heightInput = $('#info input[name="size-height"]')[0]
-        var data = [widthInput.value, heightInput.value]
-        widthInput.value = data[1]
-        heightInput.value = data[0]
+        var $widthInput = $('#info input[name="size-width"]')
+        var $heightInput = $('#info input[name="size-height"]')
+        var data = [$widthInput.val(), $heightInput.val()]
+        $widthInput.val(data[1])
+        $heightInput.val(data[0])
     })
 }
 
@@ -1245,7 +1253,7 @@ function findPosition(step, condition) {
         var iterator = gametree.makeNodeIterator.apply(null, pos)
 
         while (true) {
-            pos = step >= 0 ? iterator.next() : iterator.prev()
+            pos = step >= 0 ? iterator.nextAll() : iterator.prev()
 
             if (!pos) {
                 var root = getRootTree()
@@ -1640,7 +1648,7 @@ function sendGTPCommand(command, ignoreBlocked, callback) {
     // Cleanup
     var $forms = $('#console .inner form')
     if ($forms.length > setting.get('console.max_history_count')) {
-        $forms.eq(0).next('pre').remove()
+        $forms.eq(0).nextAll('pre').remove()
         $forms.eq(0).remove()
     }
 

--- a/view/index.js
+++ b/view/index.js
@@ -517,18 +517,18 @@ function prepareConsole() {
     })
 
     $('#console form input').on('keydown', function(e) {
-        if ([40, 38, 9].indexOf(e.code) != -1) e.preventDefault()
+        if ([40, 38, 9].indexOf(e.keyCode) != -1) e.preventDefault()
         var $inputs = $('#console form input')
 
         if ($(this).data('index') == null) $(this).data('index', $inputs.get().indexOf(this))
         var i = $(this).data('index')
         var length = $inputs.length
 
-        if ([38, 40].indexOf(e.code) != -1) {
-            if (e.code == 38) {
+        if ([38, 40].indexOf(e.keyCode) != -1) {
+            if (e.keyCode == 38) {
                 // Up
                 i = Math.max(i - 1, 0)
-            } else if (e.code == 40) {
+            } else if (e.keyCode == 40) {
                 // Down
                 i = Math.min(i + 1, length - 1)
             }
@@ -536,7 +536,7 @@ function prepareConsole() {
             $(this)
             .val(i == length - 1 ? '' : $inputs.eq(i).val())
             .data('index', i)
-        } else if (e.code == 9) {
+        } else if (e.keyCode == 9) {
             // Tab
             var tokens = $(this).val().split(' ')
             var commands = getEngineCommands()
@@ -2088,7 +2088,7 @@ function undoBoard() {
  */
 
 $(document).on('keydown', function(e) {
-    if (e.code == 27) {
+    if (e.keyCode == 27) {
         // Escape key
         closeDrawers()
     }

--- a/view/index.js
+++ b/view/index.js
@@ -298,7 +298,7 @@ function setScoringMethod(method) {
         }
     }
 
-    var results = $('#score tbody td:last-child').text()
+    var results = $('#score tbody td:last-child').get().map(function(td) { return $(td).text() })
     var diff = +results[0] - +results[1]
     var result = diff > 0 ? 'B+' :  diff < 0 ? 'W+' : 'Draw'
     if (diff != 0) result = result + Math.abs(diff)

--- a/view/index.js
+++ b/view/index.js
@@ -1,11 +1,13 @@
-var $ = require('jquery')
-var $$ = require('sprint-js')
 var fs = require('fs')
 var process = require('process')
 var remote = require('electron').remote
 var ipcRenderer = require('electron').ipcRenderer
 var clipboard = require('electron').clipboard
 var shell = require('electron').shell
+var app = remote.app
+var dialog = remote.dialog
+
+var $ = require('../modules/sprint')
 var sgf = require('../modules/sgf')
 var boardmatcher = require('../modules/boardmatcher')
 var fuzzyfinder = require('../modules/fuzzyfinder')
@@ -14,8 +16,6 @@ var sound = require('../modules/sound')
 var helper = require('../modules/helper')
 var setting = require('../modules/setting')
 var gtp = require('../modules/gtp')
-var app = remote.app
-var dialog = remote.dialog
 
 var Pikaday = require('pikaday')
 var GeminiScrollbar = require('gemini-scrollbar')
@@ -208,7 +208,7 @@ function setBoard(board) {
 
     for (var x = 0; x < board.width; x++) {
         for (var y = 0; y < board.height; y++) {
-            var $li = $$('#goban .pos_' + x + '-' + y)
+            var $li = $('#goban .pos_' + x + '-' + y)
             var $span = $li.find('.stone span')
             var sign = board.arrangement[[x, y]]
             var types = ['ghost_1', 'ghost_-1', 'siblingghost_1', 'siblingghost_-1',
@@ -250,7 +250,7 @@ function setBoard(board) {
 
     board.ghosts.forEach(function(x) {
         var v = x[0], s = x[1], type = x[2]
-        var $li = $$('#goban .pos_' + v.join('-'))
+        var $li = $('#goban .pos_' + v.join('-'))
 
         if (type == 'child') $li.addClass('ghost_' + s)
         else if (type == 'sibling') $li.addClass('siblingghost_' + s)
@@ -258,7 +258,7 @@ function setBoard(board) {
 
     // Add lines
 
-    $$('#goban hr').remove()
+    $('#goban hr').remove()
 
     board.lines.forEach(function(line) {
         $('#goban').append(

--- a/view/index.js
+++ b/view/index.js
@@ -258,7 +258,7 @@ function setBoard(board) {
     $('#goban hr').destroy()
 
     board.lines.forEach(function(line) {
-        $('#goban').grab(
+        $('#goban').append(
             new Element('hr', { class: line[2] ? 'arrow' : 'line' })
             .data('v1', line[0])
             .data('v2', line[1])
@@ -697,7 +697,7 @@ function prepareGameInfo() {
     dateInput.data('pikaday', pikaday)
     pikaday.hide()
 
-    $('body').grab(pikaday.el).on('click', function(e) {
+    $('body').append(pikaday.el).on('click', function(e) {
         if (pikaday.isVisible()
         && document.activeElement != dateInput
         && e.target != dateInput
@@ -1236,7 +1236,7 @@ function drawLine(vertex) {
 
     if (!$('#goban').data('edittool-data')) {
         var hr = new Element('hr', { class: tool }).data('v1', vertex).data('v2', vertex)
-        $('#goban').grab(hr).data('edittool-data', hr)
+        $('#goban').append(hr).data('edittool-data', hr)
     } else {
         var hr = $('#goban').data('edittool-data')
         hr.data('v2', vertex)
@@ -1645,7 +1645,7 @@ function sendGTPCommand(command, ignoreBlocked, callback) {
 
     form.find('input').val('').cloneEvents(oldform.find('input'))
     oldform.addClass('waiting').find('input').value = command.toString()
-    container.grab(pre).grab(form)
+    container.append(pre).append(form)
     if (getShowLeftSidebar()) form.find('input').focus()
 
     // Cleanup

--- a/view/index.js
+++ b/view/index.js
@@ -1,4 +1,5 @@
 var $ = require('jquery')
+var $sprint = require('sprint-js')
 var fs = require('fs')
 var process = require('process')
 var remote = require('electron').remote
@@ -207,7 +208,7 @@ function setBoard(board) {
 
     for (var x = 0; x < board.width; x++) {
         for (var y = 0; y < board.height; y++) {
-            var $li = $('#goban .pos_' + x + '-' + y)
+            var $li = $sprint('#goban .pos_' + x + '-' + y)
             var $span = $li.find('.stone span')
             var sign = board.arrangement[[x, y]]
             var types = ['ghost_1', 'ghost_-1', 'siblingghost_1', 'siblingghost_-1',
@@ -216,9 +217,7 @@ function setBoard(board) {
 
             // Clean up
 
-            types.forEach(function(x) {
-                if ($li.hasClass(x)) $li.removeClass(x)
-            })
+            types.forEach(function(x) { $li.removeClass(x) })
 
             $span.attr('title', '')
 
@@ -236,11 +235,7 @@ function setBoard(board) {
             // Set stone image
 
             if ($li.hasClass('sign_' + sign)) continue
-
-            for (var i = -1; i <= 1; i++) {
-                if ($li.hasClass('sign_' + i)) $li.removeClass('sign_' + i)
-            }
-
+            for (var i = -1; i <= 1; i++) $li.removeClass('sign_' + i)
             $li.addClass('sign_' + sign)
         }
     }
@@ -249,7 +244,7 @@ function setBoard(board) {
 
     board.ghosts.forEach(function(x) {
         var v = x[0], s = x[1], type = x[2]
-        var $li = $('#goban .pos_' + v.join('-'))
+        var $li = $sprint('#goban .pos_' + v.join('-'))
 
         if (type == 'child') $li.addClass('ghost_' + s)
         else if (type == 'sibling') $li.addClass('siblingghost_' + s)
@@ -257,7 +252,7 @@ function setBoard(board) {
 
     // Add lines
 
-    $('#goban hr').remove()
+    $sprint('#goban hr').remove()
 
     board.lines.forEach(function(line) {
         $('#goban').append(

--- a/view/index.js
+++ b/view/index.js
@@ -174,9 +174,9 @@ function getSelectedTool() {
     var tool = li.attr('class').replace('selected', '').replace('-tool', '').trim()
 
     if (tool == 'stone') {
-        return li.getElement('img').attr('src').indexOf('_1') != -1 ? 'stone_1' : 'stone_-1'
+        return li.find('img').attr('src').indexOf('_1') != -1 ? 'stone_1' : 'stone_-1'
     } else if (tool == 'line') {
-        return li.getElement('img').attr('src').indexOf('line') != -1 ? 'line' : 'arrow'
+        return li.find('img').attr('src').indexOf('line') != -1 ? 'line' : 'arrow'
     } else {
         return tool
     }
@@ -207,7 +207,7 @@ function setBoard(board) {
 
     for (var x = 0; x < board.width; x++) {
         for (var y = 0; y < board.height; y++) {
-            var li = $('#goban').getElement('.pos_' + x + '-' + y)
+            var li = $('#goban').find('.pos_' + x + '-' + y)
             var sign = board.arrangement[[x, y]]
             var types = ['ghost_1', 'ghost_-1', 'siblingghost_1', 'siblingghost_-1',
                 'circle', 'triangle', 'cross', 'square', 'label', 'point',
@@ -218,7 +218,7 @@ function setBoard(board) {
             types.forEach(function(x) {
                 if (li.hasClass(x)) li.removeClass(x)
             })
-            li.getElement('.stone span').attr('title', '')
+            li.find('.stone span').attr('title', '')
 
             // Add markups
 
@@ -227,7 +227,7 @@ function setBoard(board) {
                 var type = markup[0], label = markup[1]
 
                 if (type != '') li.addClass(type)
-                if (label != '') li.getElement('.stone span').attr('title', label)
+                if (label != '') li.find('.stone span').attr('title', label)
                 li.toggleClass('smalllabel', label.length >= 3)
             }
 
@@ -247,7 +247,7 @@ function setBoard(board) {
 
     board.ghosts.forEach(function(x) {
         var v = x[0], s = x[1], type = x[2]
-        var li = $('#goban').getElement('.pos_' + v.join('-'))
+        var li = $('#goban').find('.pos_' + v.join('-'))
 
         if (type == 'child') li.addClass('ghost_' + s)
         else if (type == 'sibling') li.addClass('siblingghost_' + s)
@@ -284,7 +284,7 @@ function setScoringMethod(method) {
 
     for (var sign = -1; sign <= 1; sign += 2) {
         var tr = $('#score tbody tr' + (sign < 0 ? ':last-child' : ''))[0]
-        var tds = tr.getElements('td')
+        var tds = tr.children('td')
 
         tds[4].attr('text', 0)
 
@@ -391,15 +391,15 @@ function loadSettings() {
 
 function prepareEditTools() {
     $('#edit ul a').on('click', function() {
-        if (!this.getParent().hasClass('selected')) {
+        if (!this.parent().hasClass('selected')) {
             $('#edit .selected').removeClass('selected')
-            this.getParent().addClass('selected')
-        } else if (this.getParent().hasClass('stone-tool')) {
-            var img = this.getElement('img')
+            this.parent().addClass('selected')
+        } else if (this.parent().hasClass('stone-tool')) {
+            var img = this.find('img')
             var black = img.attr('src') == '../img/edit/stone_1.svg'
             img.attr('src', black ? '../img/edit/stone_-1.svg' : '../img/edit/stone_1.svg')
-        } else if (this.getParent().hasClass('line-tool')) {
-            var img = this.getElement('img')
+        } else if (this.parent().hasClass('line-tool')) {
+            var img = this.find('img')
             var line = img.attr('src') == '../img/edit/line.svg'
             img.attr('src', line ? '../img/edit/arrow.svg' : '../img/edit/line.svg')
         }
@@ -518,7 +518,7 @@ function prepareConsole() {
     $('#console form').on('submit', function(e) {
         e.preventDefault()
 
-        var input = this.getElement('input')
+        var input = this.find('input')
         if (input.value.trim() == '') return
         input.blur()
 
@@ -610,17 +610,17 @@ function prepareGameInfo() {
             if (currentIndex == null) currentIndex = -1
             if (i == currentIndex) return
 
-            this.getParent().getElement('input[name^="name_"]').val(engine ? engine.name : '')
+            this.parent().find('input[name^="name_"]').val(engine ? engine.name : '')
             $(this).data('engineindex', i)
 
             if (engine) {
-                var els = $('#info').getElements('section .menu')
+                var els = $('#info').children('section .menu')
                 var other = els[0] == this ? els[1] : els[0]
                 if (other) selectEngine.call(other, null, -1)
 
                 $(this).addClass('active')
             } else {
-                $('#info').getElements('section .menu')
+                $('#info').children('section .menu')
                 .removeClass('active')
             }
         }
@@ -642,12 +642,12 @@ function prepareGameInfo() {
             return x.length == 3
         })
 
-        pikaday.el.getElements('.pika-button').forEach(function(el) {
+        pikaday.el.children('.pika-button').forEach(function(el) {
             var year = +el.attr('data-pika-year')
             var month = +el.attr('data-pika-month')
             var day = +el.attr('data-pika-day')
 
-            el.getParent().toggleClass('is-multi-selected', dates.some(function(d) {
+            el.parent().toggleClass('is-multi-selected', dates.some(function(d) {
                 return helper.equals(d, [year, month + 1, day])
             }))
         })
@@ -701,7 +701,7 @@ function prepareGameInfo() {
         if (pikaday.isVisible()
         && document.activeElement != dateInput
         && e.target != dateInput
-        && e.target.getParents('.pika-lendar').length == 0)
+        && e.target.parents('.pika-lendar').length == 0)
             pikaday.hide()
     })
 
@@ -711,7 +711,7 @@ function prepareGameInfo() {
         pikaday.show()
     }).on('blur', function() {
         setTimeout(function() {
-            if (document.activeElement.getParents('.pika-lendar').length == 0)
+            if (document.activeElement.parents('.pika-lendar').length == 0)
                 pikaday.hide()
         }, 50)
     }).on('input', function() {
@@ -723,10 +723,10 @@ function prepareGameInfo() {
     $('#info input[name^="size-"]').attr('placeholder', setting.get('game.default_board_size'))
 
     $('#info input[name="size-width"]').on('focus', function() {
-        $(this).data('link', this.value == this.getParent().getNext('input[name="size-height"]').value)
+        $(this).data('link', this.value == this.parent().getNext('input[name="size-height"]').value)
     }).on('input', function() {
         if (!$(this).data('link')) return
-        this.getParent().getNext('input[name="size-height"]').value = this.value
+        this.parent().getNext('input[name="size-height"]').value = this.value
     })
 
     $('#info span.size-swap').on('click', function() {
@@ -1518,7 +1518,7 @@ function commitGameInfo() {
     }
 
     for (var name in data) {
-        var value = info.getElement('input[name="' + name + '"]').val().trim()
+        var value = info.find('input[name="' + name + '"]').val().trim()
         rootNode[data[name]] = [value]
         if (value == '') delete rootNode[data[name]]
     }
@@ -1534,14 +1534,14 @@ function commitGameInfo() {
 
     // Handle komi
 
-    var komi = +info.getElement('input[name="komi"]').val()
+    var komi = +info.find('input[name="komi"]').val()
     if (isNaN(komi)) komi = 0
     rootNode.KM = ['' + komi]
 
     // Handle size
 
     var size = ['width', 'height'].map(function(x) {
-        var num = parseFloat(info.getElement('input[name="size-' + x + '"]').val())
+        var num = parseFloat(info.find('input[name="size-' + x + '"]').val())
         if (isNaN(num)) num = setting.get('game.default_board_size')
         return Math.min(Math.max(num, 3), 25)
     })
@@ -1551,7 +1551,7 @@ function commitGameInfo() {
 
     // Handle handicap stones
 
-    var handicapInput = info.getElement('select[name="handicap"]')
+    var handicapInput = info.find('select[name="handicap"]')
     var handicap = handicapInput.selectedIndex
 
     if (!handicapInput.disabled) {
@@ -1616,12 +1616,12 @@ function commitPreferences() {
     setting.clearEngines()
 
     $('#preferences .engines-list li').forEach(function(li) {
-        var nameinput = li.getElement('h3 input')
+        var nameinput = li.find('h3 input')
 
         setting.addEngine(
             nameinput.value.trim() == '' ? nameinput.placeholder : nameinput.value,
-            li.getElement('h3 + p input').value,
-            li.getElement('h3 + p + p input').value
+            li.find('h3 + p input').value,
+            li.find('h3 + p + p input').value
         )
     })
 
@@ -1639,14 +1639,14 @@ function sendGTPCommand(command, ignoreBlocked, callback) {
 
     var controller = getEngineController()
     var container = $('#console .inner')[0]
-    var oldform = container.getElement('form:last-child')
+    var oldform = container.find('form:last-child')
     var form = oldform.clone().cloneEvents(oldform)
     var pre = new Element('pre', { text: ' ' })
 
-    form.getElement('input').val('').cloneEvents(oldform.getElement('input'))
-    oldform.addClass('waiting').getElement('input').value = command.toString()
+    form.find('input').val('').cloneEvents(oldform.find('input'))
+    oldform.addClass('waiting').find('input').value = command.toString()
     container.grab(pre).grab(form)
-    if (getShowLeftSidebar()) form.getElement('input').focus()
+    if (getShowLeftSidebar()) form.find('input').focus()
 
     // Cleanup
     var forms = $('#console .inner form')

--- a/view/index.js
+++ b/view/index.js
@@ -802,8 +802,9 @@ function attachEngine(exec, args, genMove) {
 function detachEngine() {
     sendGTPCommand(new gtp.Command(null, 'quit'), true)
 
-    $('#console').data('controller', null)
-        .data('boardhash', null)
+    $('#console')
+    .data('controller', null)
+    .data('boardhash', null)
 
     setIsBusy(false)
 }
@@ -903,13 +904,13 @@ function makeMove(vertex, sendCommand) {
         }
 
         // Randomize shift and readjust
-        var li = $('#goban .pos_' + vertex.join('-'))
+        var $li = $('#goban .pos_' + vertex.join('-'))
         var direction = Math.floor(Math.random() * 9)
 
-        li.addClass('animate')
-        for (var i = 0; i < 9; i++) li.removeClass('shift_' + i)
-        li.addClass('shift_' + direction)
-        setTimeout(function() { li.removeClass('animate') }, 200)
+        $li.addClass('animate')
+        for (var i = 0; i < 9; i++) $li.removeClass('shift_' + i)
+        $li.addClass('shift_' + direction)
+        setTimeout(function() { $li.removeClass('animate') }, 200)
 
         readjustShifts(vertex)
     }
@@ -1305,7 +1306,7 @@ function vertexClicked(vertex, event) {
         if (event.button != 0) return
         if (getBoard().arrangement[vertex] == 0) return
 
-        var dead = !$('#goban .pos_' + vertex.join('-'))[0].hasClass('dead')
+        var dead = !$('#goban .pos_' + vertex.join('-')).hasClass('dead')
         var stones = getEstimatorMode() ? getBoard().getChain(vertex) : getBoard().getRelatedChains(vertex)
 
         stones.forEach(function(v) {
@@ -1351,7 +1352,7 @@ function vertexClicked(vertex, event) {
             makeMove(vertex)
         } else {
             if (board.arrangement[vertex] != 0) return
-            if ($('#goban .pos_' + vertex.join('-'))[0].hasClass('paint_1')) return
+            if ($('#goban .pos_' + vertex.join('-')).hasClass('paint_1')) return
 
             var i = 0
             if (Math.abs(vertex[1] - nextVertex[1]) > Math.abs(vertex[0] - nextVertex[0]))

--- a/view/index.js
+++ b/view/index.js
@@ -255,7 +255,7 @@ function setBoard(board) {
 
     // Add lines
 
-    $('#goban hr').destroy()
+    $('#goban hr').remove()
 
     board.lines.forEach(function(line) {
         $('#goban').append(
@@ -1113,21 +1113,21 @@ function useTool(vertex, event) {
 
         if (hr) {
             var v1 = hr.data('v1'), v2 = hr.data('v2')
-            var toDelete = $('#goban hr').filter(function(x) {
-                var w1 = x.data('v1'), w2 = x.data('v2')
+            var toDelete = $('#goban hr').get().filter(function(x) {
+                var w1 = $(x).data('v1'), w2 = $(x).data('v2')
                 var result = x != hr
                     && w1[0] == v1[0] && w1[1] == v1[1]
                     && w2[0] == v2[0] && w2[1] == v2[1]
 
-                if (tool == 'line' || x.hasClass('line')) result = result || x != hr
+                if (tool == 'line' || $(x).hasClass('line')) result = result || x != hr
                     && w1[0] == v2[0] && w1[1] == v2[1]
                     && w2[0] == v1[0] && w2[1] == v1[1]
 
                 return result
             })
 
-            if (toDelete.length != 0) hr.destroy()
-            toDelete.destroy()
+            if (toDelete.length != 0) hr.remove()
+            toDelete.remove()
         }
 
         $('#goban').data('edittool-data', null)
@@ -1138,14 +1138,14 @@ function useTool(vertex, event) {
         node.AR = []
         board.lines = []
 
-        $('#goban hr').forEach(function(hr) {
-            var p1 = sgf.vertex2point(hr.data('v1'))
-            var p2 = sgf.vertex2point(hr.data('v2'))
+        $('#goban hr').get().forEach(function(hr) {
+            var p1 = sgf.vertex2point($(hr).data('v1'))
+            var p2 = sgf.vertex2point($(hr).data('v2'))
 
             if (p1 == p2) return
 
-            node[hr.hasClass('arrow') ? 'AR' : 'LN'].push(p1 + ':' + p2)
-            board.lines.push([hr.data('v1'), hr.data('v2'), hr.hasClass('arrow')])
+            node[$(hr).hasClass('arrow') ? 'AR' : 'LN'].push(p1 + ':' + p2)
+            board.lines.push([$(hr).data('v1'), $(hr).data('v2'), $(hr).hasClass('arrow')])
         })
 
         if (node.LN.length == 0) delete node.LN

--- a/view/index.js
+++ b/view/index.js
@@ -171,12 +171,12 @@ function getGraphNode(tree, index) {
 
 function getSelectedTool() {
     var li = $('#edit .selected')[0]
-    var tool = li.get('class').replace('selected', '').replace('-tool', '').trim()
+    var tool = li.attr('class').replace('selected', '').replace('-tool', '').trim()
 
     if (tool == 'stone') {
-        return li.getElement('img').get('src').indexOf('_1') != -1 ? 'stone_1' : 'stone_-1'
+        return li.getElement('img').attr('src').indexOf('_1') != -1 ? 'stone_1' : 'stone_-1'
     } else if (tool == 'line') {
-        return li.getElement('img').get('src').indexOf('line') != -1 ? 'line' : 'arrow'
+        return li.getElement('img').attr('src').indexOf('line') != -1 ? 'line' : 'arrow'
     } else {
         return tool
     }
@@ -289,12 +289,12 @@ function setScoringMethod(method) {
         tds[4].attr('text', 0)
 
         for (var i = 0; i <= 3; i++) {
-            if (tds[i].hasClass('disabled') || isNaN(+tds[i].get('text'))) continue
-            tds[4].attr('text', +tds[4].get('text') + +tds[i].get('text'))
+            if (tds[i].hasClass('disabled') || isNaN(+tds[i].attr('text'))) continue
+            tds[4].attr('text', +tds[4].attr('text') + +tds[i].attr('text'))
         }
     }
 
-    var results = $('#score tbody td:last-child').get('text')
+    var results = $('#score tbody td:last-child').attr('text')
     var diff = +results[0] - +results[1]
     var result = diff > 0 ? 'B+' :  diff < 0 ? 'W+' : 'Draw'
     if (diff != 0) result = result + Math.abs(diff)
@@ -396,11 +396,11 @@ function prepareEditTools() {
             this.getParent().addClass('selected')
         } else if (this.getParent().hasClass('stone-tool')) {
             var img = this.getElement('img')
-            var black = img.get('src') == '../img/edit/stone_1.svg'
+            var black = img.attr('src') == '../img/edit/stone_1.svg'
             img.attr('src', black ? '../img/edit/stone_-1.svg' : '../img/edit/stone_1.svg')
         } else if (this.getParent().hasClass('line-tool')) {
             var img = this.getElement('img')
-            var line = img.get('src') == '../img/edit/line.svg'
+            var line = img.attr('src') == '../img/edit/line.svg'
             img.attr('src', line ? '../img/edit/arrow.svg' : '../img/edit/line.svg')
         }
     })
@@ -643,9 +643,9 @@ function prepareGameInfo() {
         })
 
         pikaday.el.getElements('.pika-button').forEach(function(el) {
-            var year = +el.get('data-pika-year')
-            var month = +el.get('data-pika-month')
-            var day = +el.get('data-pika-day')
+            var year = +el.attr('data-pika-year')
+            var month = +el.attr('data-pika-month')
+            var day = +el.attr('data-pika-day')
 
             el.getParent().toggleClass('is-multi-selected', dates.some(function(d) {
                 return helper.equals(d, [year, month + 1, day])
@@ -1592,7 +1592,7 @@ function commitGameInfo() {
 }
 
 function commitScore() {
-    var result = $('#score .result').get('text')
+    var result = $('#score .result').attr('text')
 
     showGameInfo()
     $('#info input[name="result"]').val(result)

--- a/view/index.js
+++ b/view/index.js
@@ -1254,7 +1254,7 @@ function findPosition(step, condition) {
         var iterator = gametree.makeNodeIterator.apply(null, pos)
 
         while (true) {
-            pos = step >= 0 ? iterator.nextAll() : iterator.prev()
+            pos = step >= 0 ? iterator.next() : iterator.prev()
 
             if (!pos) {
                 var root = getRootTree()

--- a/view/index.js
+++ b/view/index.js
@@ -436,7 +436,6 @@ function prepareGameGraph() {
     s.bind('clickNode', function(e) {
         setCurrentTreePosition.apply(null, getTreePos(e).concat([true]))
     }).bind('rightClickNode', function(e) {
-        console.log(e)
         openNodeMenu.apply(null, getTreePos(e).concat([e.data.captor]))
     })
 
@@ -1583,7 +1582,7 @@ function commitGameInfo() {
 
     if (!$info.hasClass('disabled')) {
         var engines = setting.getEngines()
-        var indices = $('#info section .menu').map(function(x) { return x.data('engineindex') })
+        var indices = $('#info section .menu').get().map(function(x) { return $(x).data('engineindex') })
         var max = Math.max.apply(null, indices)
         var sign = indices.indexOf(max) == 0 ? 1 : -1
 

--- a/view/index.js
+++ b/view/index.js
@@ -170,13 +170,13 @@ function getGraphNode(tree, index) {
 }
 
 function getSelectedTool() {
-    var li = $('#edit .selected')[0]
-    var tool = li.attr('class').replace('selected', '').replace('-tool', '').trim()
+    var $li = $('#edit .selected')
+    var tool = $li.attr('class').replace('selected', '').replace('-tool', '').trim()
 
     if (tool == 'stone') {
-        return li.find('img').attr('src').indexOf('_1') != -1 ? 'stone_1' : 'stone_-1'
+        return $li.find('img').attr('src').indexOf('_1') != -1 ? 'stone_1' : 'stone_-1'
     } else if (tool == 'line') {
-        return li.find('img').attr('src').indexOf('line') != -1 ? 'line' : 'arrow'
+        return $li.find('img').attr('src').indexOf('line') != -1 ? 'line' : 'arrow'
     } else {
         return tool
     }
@@ -327,15 +327,15 @@ function setUndoable(undoable, tooltip) {
         if (!tooltip) tooltip = 'Undo'
 
         $('#bar header .undo').attr('title', tooltip)
-        document.body
-            .addClass('undoable')
-            .data('undodata-root', rootTree)
-            .data('undodata-pos', position)
+        $('body')
+        .addClass('undoable')
+        .data('undodata-root', rootTree)
+        .data('undodata-pos', position)
     } else {
-        document.body
-            .removeClass('undoable')
-            .data('undodata-root', null)
-            .data('undodata-pos', null)
+        $('body')
+        .removeClass('undoable')
+        .data('undodata-root', null)
+        .data('undodata-pos', null)
     }
 }
 
@@ -392,17 +392,17 @@ function loadSettings() {
 
 function prepareEditTools() {
     $('#edit ul a').on('click', function() {
-        if (!this.parent().hasClass('selected')) {
+        var $img = $(this).find('img')
+
+        if (!$(this).parent().hasClass('selected')) {
             $('#edit .selected').removeClass('selected')
-            this.parent().addClass('selected')
-        } else if (this.parent().hasClass('stone-tool')) {
-            var img = this.find('img')
-            var black = img.attr('src') == '../img/edit/stone_1.svg'
-            img.attr('src', black ? '../img/edit/stone_-1.svg' : '../img/edit/stone_1.svg')
-        } else if (this.parent().hasClass('line-tool')) {
-            var img = this.find('img')
-            var line = img.attr('src') == '../img/edit/line.svg'
-            img.attr('src', line ? '../img/edit/arrow.svg' : '../img/edit/line.svg')
+            $(this).parent().addClass('selected')
+        } else if ($(this).parent().hasClass('stone-tool')) {
+            var black = $img.attr('src').indexOf('_1') >= 0
+            $img.attr('src', black ? '../img/edit/stone_-1.svg' : '../img/edit/stone_1.svg')
+        } else if ($(this).parent().hasClass('line-tool')) {
+            var line = $img.attr('src').indexOf('line') >= 0
+            $img.attr('src', line ? '../img/edit/arrow.svg' : '../img/edit/line.svg')
         }
     })
 }
@@ -440,7 +440,7 @@ function prepareGameGraph() {
 }
 
 function prepareSlider() {
-    var $slider = $('#sidebar .slider .inner').eq(0)
+    var $slider = $('#sidebar .slider .inner')
 
     var changeSlider = function(percentage) {
         percentage = Math.min(1, Math.max(0, percentage))
@@ -455,23 +455,23 @@ function prepareSlider() {
     }
 
     var mouseMoveHandler = function(e) {
-        if (e.event.buttons != 1 || !$slider.data('mousedown'))
+        if (e.button != 0 || !$slider.data('mousedown'))
             return
 
-        var percentage = (e.event.clientY - $slider.position().top) / $slider.innerHeight()
+        var percentage = (e.originalEvent.clientY - $slider.position().top) / $slider.innerHeight()
         changeSlider(percentage)
         document.onselectstart = function() { return false }
     }
 
     $slider.on('mousedown', function(e) {
-        if (e.event.buttons != 1) return
+        if (e.button != 0) return
 
         $(this).data('mousedown', true).addClass('active')
         mouseMoveHandler(e)
     }).on('touchstart', function() {
         $(this).addClass('active')
     }).on('touchmove', function(e) {
-        var percentage = (e.client.y - $slider.position().top) / $slider.innerHeight()
+        var percentage = (e.originalEvent.client.y - $slider.position().top) / $slider.innerHeight()
         changeSlider(percentage)
     }).on('touchend', function() {
         $(this).removeClass('active')
@@ -501,8 +501,8 @@ function prepareDragDropFiles() {
     }).on('drop', function(e) {
         e.preventDefault()
 
-        if (e.event.dataTransfer.files.length == 0) return
-        loadFile(e.event.dataTransfer.files[0].path)
+        if (e.originalEvent.dataTransfer.files.length == 0) return
+        loadFile(e.originalEvent.dataTransfer.files[0].path)
     })
 }
 
@@ -510,7 +510,7 @@ function prepareConsole() {
     $('#console form').on('submit', function(e) {
         e.preventDefault()
 
-        var input = this.find('input')
+        var input = $(this).find('input')
         if (input.value.trim() == '') return
         input.blur()
 
@@ -602,7 +602,7 @@ function prepareGameInfo() {
             if (currentIndex == null) currentIndex = -1
             if (i == currentIndex) return
 
-            this.parent().find('input[name^="name_"]').val(engine ? engine.name : '')
+            $(this).parent().find('input[name^="name_"]').val(engine ? engine.name : '')
             $(this).data('engineindex', i)
 
             if (engine) {
@@ -715,10 +715,10 @@ function prepareGameInfo() {
     $('#info input[name^="size-"]').attr('placeholder', setting.get('game.default_board_size'))
 
     $('#info input[name="size-width"]').on('focus', function() {
-        $(this).data('link', this.value == this.parent().getNext('input[name="size-height"]').value)
+        $(this).data('link', this.value == $(this).parent().next('input[name="size-height"]').value)
     }).on('input', function() {
         if (!$(this).data('link')) return
-        this.parent().getNext('input[name="size-height"]').value = this.value
+        $(this).parent().next('input[name="size-height"]').value = this.value
     })
 
     $('#info span.size-swap').on('click', function() {
@@ -1443,7 +1443,7 @@ function updateCommentText() {
         return [null, null]
     })()))
 
-    $('#properties .gm-scroll-view')[0].scrollTo(0, 0)
+    $('#properties .gm-scroll-view').eq(0).scrollTop(0)
     $('#properties').data('scrollbar').update()
 }
 
@@ -1640,10 +1640,10 @@ function sendGTPCommand(command, ignoreBlocked, callback) {
     if (getShowLeftSidebar()) $form.find('input').focus()
 
     // Cleanup
-    var forms = $('#console .inner form')
-    if (forms.length > setting.get('console.max_history_count')) {
-        forms[0].getNext('pre').remove()
-        forms[0].remove()
+    var $forms = $('#console .inner form')
+    if ($forms.length > setting.get('console.max_history_count')) {
+        $forms.eq(0).next('pre').remove()
+        $forms.eq(0).remove()
     }
 
     var listener = function(response, c) {
@@ -1653,10 +1653,10 @@ function sendGTPCommand(command, ignoreBlocked, callback) {
         if (callback) callback(response)
 
         // Update scrollbars
-        var view = $('#console .gm-scroll-view')[0]
+        var $view = $('#console .gm-scroll-view')
         var scrollbar = $('#console').data('scrollbar')
 
-        view.scrollTo(0, view.getScrollSize().y)
+        $view.scrollTop($view.get(0).scrollHeight)
         if (scrollbar) scrollbar.update()
     }
 
@@ -1743,20 +1743,20 @@ function askForSave() {
 }
 
 function startAutoScroll(direction, delay) {
-    if (direction > 0 && !$('#sidebar .slider a.next')[0].data('mousedown')
-    || direction < 0 && !$('#sidebar .slider a.prev')[0].data('mousedown')) return
+    if (direction > 0 && !$('#sidebar .slider a.next').data('mousedown')
+    || direction < 0 && !$('#sidebar .slider a.prev').data('mousedown')) return
 
     if (delay == null) delay = setting.get('autoscroll.max_interval')
     delay = Math.max(setting.get('autoscroll.min_interval'), delay)
 
-    var slider = $('#sidebar .slider')[0]
-    clearTimeout(slider.data('autoscrollid'))
+    var $slider = $('#sidebar .slider')
+    clearTimeout($slider.data('autoscrollid'))
 
     if (direction > 0) goForward()
     else goBack()
     updateSlider()
 
-    slider.data('autoscrollid', setTimeout(function() {
+    $slider.data('autoscrollid', setTimeout(function() {
         startAutoScroll(direction, delay - setting.get('autoscroll.diff'))
     }, delay))
 }
@@ -2096,18 +2096,15 @@ $(document).on('keydown', function(e) {
     newFile()
 
     $('#main, #graph canvas:last-child, #graph .slider').on('mousewheel', function(e) {
-        if (e.wheel < 0) goForward()
-        else if (e.wheel > 0) goBack()
+        if (e.originalEvent.wheelDelta < 0) goForward()
+        else if (e.originalEvent.wheelDelta > 0) goBack()
     })
 })
 
 $(window).on('resize', function() {
     resizeBoard()
 }).on('beforeunload', function(e) {
-    if (!askForSave()) {
-        e.event.returnValue = 'false'
-        return
-    }
+    if (!askForSave()) return 'false'
 
     detachEngine()
 
@@ -2115,6 +2112,6 @@ $(window).on('resize', function() {
     if (win.isMaximized() || win.isMinimized() || win.isFullScreen()) return
 
     setting
-    .attr('window.width', $('body').width())
-    .attr('window.height', $('body').height())
+    .set('window.width', $('body').width())
+    .set('window.height', $('body').height())
 })

--- a/view/index.js
+++ b/view/index.js
@@ -287,11 +287,11 @@ function setScoringMethod(method) {
         var tr = $('#score tbody tr' + (sign < 0 ? ':last-child' : ''))[0]
         var tds = tr.children('td')
 
-        tds[4].attr('text', 0)
+        tds[4].text(0)
 
         for (var i = 0; i <= 3; i++) {
             if (tds[i].hasClass('disabled') || isNaN(+tds[i].attr('text'))) continue
-            tds[4].attr('text', +tds[4].attr('text') + +tds[i].attr('text'))
+            tds[4].text(+tds[4].attr('text') + +tds[i].attr('text'))
         }
     }
 
@@ -300,7 +300,7 @@ function setScoringMethod(method) {
     var result = diff > 0 ? 'B+' :  diff < 0 ? 'W+' : 'Draw'
     if (diff != 0) result = result + Math.abs(diff)
 
-    $('#score .result').attr('text', result)
+    $('#score .result').text(result)
 }
 
 function getKomi() {

--- a/view/index.js
+++ b/view/index.js
@@ -408,10 +408,10 @@ function prepareEditTools() {
 }
 
 function prepareGameGraph() {
-    var container = $('#graph')
+    var $container = $('#graph')
     var s = new sigma({
         renderer: {
-            container: container,
+            container: $container.get(0),
             type: 'canvas'
         },
         settings: {
@@ -436,14 +436,11 @@ function prepareGameGraph() {
         openNodeMenu.apply(null, getTreePos(e).concat([e.data.captor]))
     })
 
-    container.data('sigma', s)
+    $container.data('sigma', s)
 }
 
 function prepareSlider() {
     var $slider = $('#sidebar .slider .inner').eq(0)
-    Element.NativeEvents.touchstart = 2
-    Element.NativeEvents.touchmove = 2
-    Element.NativeEvents.touchend = 2
 
     var changeSlider = function(percentage) {
         percentage = Math.min(1, Math.max(0, percentage))
@@ -493,18 +490,12 @@ function prepareSlider() {
         startAutoScroll($(this).hasClass('next') ? 1 : -1)
     })
 
-    document.on('mouseup', function() {
+    $(document).on('mouseup', function() {
         $('#sidebar .slider a').data('mousedown', false)
     })
 }
 
 function prepareDragDropFiles() {
-    Element.NativeEvents.dragover = 2
-    Element.NativeEvents.dragenter = 2
-    Element.NativeEvents.dragleave = 2
-    Element.NativeEvents.dragstart = 2
-    Element.NativeEvents.drop = 2
-
     $('body').on('dragover', function(e) {
         e.preventDefault()
     }).on('drop', function(e) {
@@ -631,24 +622,24 @@ function prepareGameInfo() {
 
     // Prepare date input
 
-    var dateInput = $('#info input[name="date"]')[0]
+    var $dateInput = $('#info input[name="date"]').eq(0)
     var adjustPosition = function(pikaday) {
-        pikaday.el
+        $(pikaday.el)
         .css('position', 'absolute')
-        .css('left', dateInput.position().left)
-        .css('top', dateInput.position().top - pikaday.el.innerHeight())
+        .css('left', $dateInput.position().left)
+        .css('top', $dateInput.position().top - $(pikaday.el).innerHeight())
     }
     var markDates = function(pikaday) {
-        var dates = (sgf.string2dates(dateInput.value) || []).filter(function(x) {
+        var dates = (sgf.string2dates($dateInput.value) || []).filter(function(x) {
             return x.length == 3
         })
 
-        pikaday.el.children('.pika-button').forEach(function(el) {
-            var year = +el.attr('data-pika-year')
-            var month = +el.attr('data-pika-month')
-            var day = +el.attr('data-pika-day')
+        $(pikaday.el).children('.pika-button').get().forEach(function(el) {
+            var year = +$(el).attr('data-pika-year')
+            var month = +$(el).attr('data-pika-month')
+            var day = +$(el).attr('data-pika-day')
 
-            el.parent().toggleClass('is-multi-selected', dates.some(function(d) {
+            $(el).parent().toggleClass('is-multi-selected', dates.some(function(d) {
                 return helper.equals(d, [year, month + 1, day])
             }))
         })
@@ -660,7 +651,7 @@ function prepareGameInfo() {
         onOpen: function() {
             if (!pikaday) return
 
-            var dates = (sgf.string2dates(dateInput.value) || []).filter(function(x) {
+            var dates = (sgf.string2dates($dateInput.val()) || []).filter(function(x) {
                 return x.length == 3
             })
 
@@ -678,10 +669,10 @@ function prepareGameInfo() {
             adjustPosition(pikaday)
             markDates(pikaday)
 
-            dateInput.focus()
+            $dateInput.focus()
         },
         onSelect: function() {
-            var dates = sgf.string2dates(dateInput.value) || []
+            var dates = sgf.string2dates($dateInput.val()) || []
             var date = pikaday.getDate()
             date = [date.getFullYear(), date.getMonth() + 1, date.getDate()]
 
@@ -691,24 +682,24 @@ function prepareGameInfo() {
                 dates = dates.filter(function(x) { return !helper.equals(x, date) })
             }
 
-            dateInput.value = sgf.dates2string(dates.sort(helper.lexicalCompare))
+            $dateInput.val(sgf.dates2string(dates.sort(helper.lexicalCompare)))
         }
     })
 
-    dateInput.data('pikaday', pikaday)
+    $dateInput.data('pikaday', pikaday)
     pikaday.hide()
 
     $('body').append(pikaday.el).on('click', function(e) {
         if (pikaday.isVisible()
-        && document.activeElement != dateInput
-        && e.target != dateInput
+        && document.activeElement != $dateInput.get(0)
+        && e.target != $dateInput.get(0)
         && e.target.parents('.pika-lendar').length == 0)
             pikaday.hide()
     })
 
     $(window).on('resize', function() { adjustPosition(pikaday) })
 
-    dateInput.on('focus', function() {
+    $dateInput.on('focus', function() {
         pikaday.show()
     }).on('blur', function() {
         setTimeout(function() {
@@ -759,8 +750,7 @@ function updateFileHash() {
 function loadEngines() {
     // Load engines list
 
-    var ul = $('#preferences .engines-list ul')[0]
-    ul.empty()
+    $('#preferences .engines-list ul').empty()
 
     setting.getEngines().forEach(function(engine) {
         addEngineItem(engine.name, engine.path, engine.args)

--- a/view/index.js
+++ b/view/index.js
@@ -462,7 +462,7 @@ function prepareSlider() {
         if (e.button != 0 || !$slider.data('mousedown'))
             return
 
-        var percentage = (e.originalEvent.clientY - $slider.position().top) / $slider.height()
+        var percentage = (e.originalEvent.clientY - $slider.offset().top) / $slider.height()
         changeSlider(percentage)
         document.onselectstart = function() { return false }
     }
@@ -475,7 +475,7 @@ function prepareSlider() {
     }).on('touchstart', function() {
         $(this).addClass('active')
     }).on('touchmove', function(e) {
-        var percentage = (e.originalEvent.client.y - $slider.position().top) / $slider.height()
+        var percentage = (e.originalEvent.client.y - $slider.offset().top) / $slider.height()
         changeSlider(percentage)
     }).on('touchend', function() {
         $(this).removeClass('active')

--- a/view/index.js
+++ b/view/index.js
@@ -462,7 +462,7 @@ function prepareSlider() {
         if (e.button != 0 || !$slider.data('mousedown'))
             return
 
-        var percentage = (e.originalEvent.clientY - $slider.position().top) / $slider.innerHeight()
+        var percentage = (e.originalEvent.clientY - $slider.position().top) / $slider.height()
         changeSlider(percentage)
         document.onselectstart = function() { return false }
     }
@@ -475,7 +475,7 @@ function prepareSlider() {
     }).on('touchstart', function() {
         $(this).addClass('active')
     }).on('touchmove', function(e) {
-        var percentage = (e.originalEvent.client.y - $slider.position().top) / $slider.innerHeight()
+        var percentage = (e.originalEvent.client.y - $slider.position().top) / $slider.height()
         changeSlider(percentage)
     }).on('touchend', function() {
         $(this).removeClass('active')
@@ -635,7 +635,7 @@ function prepareGameInfo() {
         $(pikaday.el)
         .css('position', 'absolute')
         .css('left', $dateInput.position().left)
-        .css('top', $dateInput.position().top - $(pikaday.el).innerHeight())
+        .css('top', $dateInput.position().top - $(pikaday.el).height())
     }
     var markDates = function(pikaday) {
         var dates = (sgf.string2dates($dateInput.value) || []).filter(function(x) {
@@ -677,7 +677,7 @@ function prepareGameInfo() {
             adjustPosition(pikaday)
             markDates(pikaday)
 
-            $dateInput.focus()
+            $dateInput.get(0).focus()
         },
         onSelect: function() {
             var dates = sgf.string2dates($dateInput.val()) || []
@@ -1651,7 +1651,7 @@ function sendGTPCommand(command, ignoreBlocked, callback) {
     $form.find('input').val('')
     $oldform.addClass('waiting').find('input').val(command.toString())
     $container.append($pre).append($form)
-    if (getShowLeftSidebar()) $form.find('input').focus()
+    if (getShowLeftSidebar()) $form.find('input').get(0).focus()
 
     // Cleanup
     var $forms = $('#console .inner form')

--- a/view/index.js
+++ b/view/index.js
@@ -638,7 +638,7 @@ function prepareGameInfo() {
         .css('top', $dateInput.position().top - $(pikaday.el).height())
     }
     var markDates = function(pikaday) {
-        var dates = (sgf.string2dates($dateInput.value) || []).filter(function(x) {
+        var dates = (sgf.string2dates($dateInput.val()) || []).filter(function(x) {
             return x.length == 3
         })
 
@@ -1625,8 +1625,8 @@ function commitPreferences() {
 
         setting.addEngine(
             nameinput.value.trim() == '' ? nameinput.placeholder : nameinput.value,
-            $(li).find('h3 + p input').value,
-            $(li).find('h3 + p + p input').value
+            $(li).find('h3 + p input').val(),
+            $(li).find('h3 + p + p input').val()
         )
     })
 

--- a/view/index.js
+++ b/view/index.js
@@ -1621,10 +1621,10 @@ function commitPreferences() {
     setting.clearEngines()
 
     $('#preferences .engines-list li').get().forEach(function(li) {
-        var nameinput = $(li).find('h3 input')
+        var $nameinput = $(li).find('h3 input')
 
         setting.addEngine(
-            nameinput.value.trim() == '' ? nameinput.placeholder : nameinput.value,
+            $nameinput.val().trim() == '' ? $nameinput.attr('placeholder') : $nameinput.val(),
             $(li).find('h3 + p input').val(),
             $(li).find('h3 + p + p input').val()
         )

--- a/view/index.js
+++ b/view/index.js
@@ -701,7 +701,7 @@ function prepareGameInfo() {
         if (pikaday.isVisible()
         && document.activeElement != $dateInput.get(0)
         && e.originalEvent.target != $dateInput.get(0)
-        && e.originalEvent.target.parents('.pika-lendar').length == 0)
+        && $(e.originalEvent.target).parents('.pika-lendar').length == 0)
             pikaday.hide()
     })
 
@@ -713,7 +713,7 @@ function prepareGameInfo() {
     })
     .on('blur', function() {
         setTimeout(function() {
-            if (document.activeElement.parents('.pika-lendar').length == 0)
+            if ($(document.activeElement).parents('.pika-lendar').length == 0)
                 pikaday.hide()
         }, 50)
     })

--- a/view/index.js
+++ b/view/index.js
@@ -568,15 +568,15 @@ function prepareConsole() {
 }
 
 function prepareGameInfo() {
-    $('#info button[type="submit"]').on('click', function() {
+    $('#info button[type="submit"]').on('click', function(e) {
+        e.preventDefault()
         commitGameInfo()
         closeGameInfo()
-        return false
     })
 
-    $('#info button[type="reset"]').on('click', function() {
+    $('#info button[type="reset"]').on('click', function(e) {
+        e.preventDefault()
         closeGameInfo()
-        return false
     })
 
     $('#info .currentplayer').on('click', function() {
@@ -2110,6 +2110,7 @@ $(document).on('keydown', function(e) {
     newFile()
 
     $('#main, #graph canvas:last-child, #graph .slider').on('mousewheel', function(e) {
+        e.preventDefault()
         if (e.wheelDelta < 0) goForward()
         else if (e.wheelDelta > 0) goBack()
     })

--- a/view/index.js
+++ b/view/index.js
@@ -207,7 +207,7 @@ function setBoard(board) {
 
     for (var x = 0; x < board.width; x++) {
         for (var y = 0; y < board.height; y++) {
-            var li = $('#goban').find('.pos_' + x + '-' + y)
+            var $li = $('#goban .pos_' + x + '-' + y)
             var sign = board.arrangement[[x, y]]
             var types = ['ghost_1', 'ghost_-1', 'siblingghost_1', 'siblingghost_-1',
                 'circle', 'triangle', 'cross', 'square', 'label', 'point',
@@ -215,10 +215,8 @@ function setBoard(board) {
 
             // Clean up
 
-            types.forEach(function(x) {
-                if (li.hasClass(x)) li.removeClass(x)
-            })
-            li.find('.stone span').attr('title', '')
+            types.forEach(function(x) { $li.toggleClass(x, false) })
+            $li.find('.stone span').attr('title', '')
 
             // Add markups
 
@@ -226,20 +224,20 @@ function setBoard(board) {
                 var markup = board.markups[[x, y]]
                 var type = markup[0], label = markup[1]
 
-                if (type != '') li.addClass(type)
-                if (label != '') li.find('.stone span').attr('title', label)
-                li.toggleClass('smalllabel', label.length >= 3)
+                if (type != '') $li.addClass(type)
+                if (label != '') $li.find('.stone span').attr('title', label)
+                $li.toggleClass('smalllabel', label.length >= 3)
             }
 
             // Set stone image
 
-            if (li.hasClass('sign_' + sign)) continue
+            if ($li.hasClass('sign_' + sign)) continue
 
             for (var i = -1; i <= 1; i++) {
-                if (li.hasClass('sign_' + i)) li.removeClass('sign_' + i)
+                $li.toggleClass('sign_' + i, false)
             }
 
-            li.addClass('sign_' + sign)
+            $li.addClass('sign_' + sign)
         }
     }
 
@@ -247,7 +245,7 @@ function setBoard(board) {
 
     board.ghosts.forEach(function(x) {
         var v = x[0], s = x[1], type = x[2]
-        var li = $('#goban').find('.pos_' + v.join('-'))
+        var li = $('#goban .pos_' + v.join('-'))
 
         if (type == 'child') li.addClass('ghost_' + s)
         else if (type == 'sibling') li.addClass('siblingghost_' + s)
@@ -897,7 +895,7 @@ function makeMove(vertex, sendCommand) {
         }
 
         // Randomize shift and readjust
-        var li = $('#goban .pos_' + vertex[0] + '-' + vertex[1])
+        var li = $('#goban .pos_' + vertex.join('-'))
         var direction = Math.floor(Math.random() * 9)
 
         li.addClass('animate')
@@ -1345,7 +1343,7 @@ function vertexClicked(vertex, event) {
             makeMove(vertex)
         } else {
             if (board.arrangement[vertex] != 0) return
-            if ($('#goban .pos_' + vertex[0] + '-' + vertex[1])[0].hasClass('paint_1')) return
+            if ($('#goban .pos_' + vertex.join('-'))[0].hasClass('paint_1')) return
 
             var i = 0
             if (Math.abs(vertex[1] - nextVertex[1]) > Math.abs(vertex[0] - nextVertex[0]))

--- a/view/index.js
+++ b/view/index.js
@@ -1,4 +1,4 @@
-var $ = require('cash-dom')
+var $ = require('jquery')
 var fs = require('fs')
 var process = require('process')
 var remote = require('electron').remote

--- a/view/index.js
+++ b/view/index.js
@@ -208,6 +208,7 @@ function setBoard(board) {
     for (var x = 0; x < board.width; x++) {
         for (var y = 0; y < board.height; y++) {
             var $li = $('#goban .pos_' + x + '-' + y)
+            var $span = $li.find('.stone span')
             var sign = board.arrangement[[x, y]]
             var types = ['ghost_1', 'ghost_-1', 'siblingghost_1', 'siblingghost_-1',
                 'circle', 'triangle', 'cross', 'square', 'label', 'point',
@@ -215,8 +216,11 @@ function setBoard(board) {
 
             // Clean up
 
-            types.forEach(function(x) { $li.toggleClass(x, false) })
-            $li.find('.stone span').attr('title', '')
+            types.forEach(function(x) {
+                if ($li.hasClass(x)) $li.removeClass(x)
+            })
+
+            $span.attr('title', '')
 
             // Add markups
 
@@ -225,7 +229,7 @@ function setBoard(board) {
                 var type = markup[0], label = markup[1]
 
                 if (type != '') $li.addClass(type)
-                if (label != '') $li.find('.stone span').attr('title', label)
+                if (label != '') $span.attr('title', label)
                 $li.toggleClass('smalllabel', label.length >= 3)
             }
 
@@ -234,7 +238,7 @@ function setBoard(board) {
             if ($li.hasClass('sign_' + sign)) continue
 
             for (var i = -1; i <= 1; i++) {
-                $li.toggleClass('sign_' + i, false)
+                if ($li.hasClass('sign_' + i)) $li.removeClass('sign_' + i)
             }
 
             $li.addClass('sign_' + sign)

--- a/view/index.js
+++ b/view/index.js
@@ -2118,7 +2118,7 @@ $(document).on('keydown', function(e) {
 $(window).on('resize', function() {
     resizeBoard()
 }).on('beforeunload', function(e) {
-    if (!askForSave()) return 'false'
+    if (!askForSave()) e.returnValue = 'false'
 
     detachEngine()
 

--- a/view/index.js
+++ b/view/index.js
@@ -290,12 +290,12 @@ function setScoringMethod(method) {
         tds[4].text(0)
 
         for (var i = 0; i <= 3; i++) {
-            if (tds[i].hasClass('disabled') || isNaN(+tds[i].attr('text'))) continue
-            tds[4].text(+tds[4].attr('text') + +tds[i].attr('text'))
+            if (tds[i].hasClass('disabled') || isNaN(+tds[i].text())) continue
+            tds[4].text(+tds[4].text() + +tds[i].text())
         }
     }
 
-    var results = $('#score tbody td:last-child').attr('text')
+    var results = $('#score tbody td:last-child').text()
     var diff = +results[0] - +results[1]
     var result = diff > 0 ? 'B+' :  diff < 0 ? 'W+' : 'Draw'
     if (diff != 0) result = result + Math.abs(diff)
@@ -1583,7 +1583,7 @@ function commitGameInfo() {
 }
 
 function commitScore() {
-    var result = $('#score .result').attr('text')
+    var result = $('#score .result').text()
 
     showGameInfo()
     $('#info input[name="result"]').val(result)

--- a/view/index.js
+++ b/view/index.js
@@ -462,7 +462,7 @@ function prepareSlider() {
         if (e.button != 0 || !$slider.data('mousedown'))
             return
 
-        var percentage = (e.originalEvent.clientY - $slider.offset().top) / $slider.height()
+        var percentage = (e.clientY - $slider.offset().top) / $slider.height()
         changeSlider(percentage)
         document.onselectstart = function() { return false }
     }
@@ -475,7 +475,7 @@ function prepareSlider() {
     }).on('touchstart', function() {
         $(this).addClass('active')
     }).on('touchmove', function(e) {
-        var percentage = (e.originalEvent.client.y - $slider.offset().top) / $slider.height()
+        var percentage = (e.client.y - $slider.offset().top) / $slider.height()
         changeSlider(percentage)
     }).on('touchend', function() {
         $(this).removeClass('active')
@@ -505,8 +505,8 @@ function prepareDragDropFiles() {
     }).on('drop', function(e) {
         e.preventDefault()
 
-        if (e.originalEvent.dataTransfer.files.length == 0) return
-        loadFile(e.originalEvent.dataTransfer.files[0].path)
+        if (e.dataTransfer.files.length == 0) return
+        loadFile(e.dataTransfer.files[0].path)
     })
 }
 
@@ -700,8 +700,8 @@ function prepareGameInfo() {
     $('body').append(pikaday.el).on('click', function(e) {
         if (pikaday.isVisible()
         && document.activeElement != $dateInput.get(0)
-        && e.originalEvent.target != $dateInput.get(0)
-        && $(e.originalEvent.target).parents('.pika-lendar').length == 0)
+        && e.target != $dateInput.get(0)
+        && $(e.target).parents('.pika-lendar').length == 0)
             pikaday.hide()
     })
 
@@ -2110,8 +2110,8 @@ $(document).on('keydown', function(e) {
     newFile()
 
     $('#main, #graph canvas:last-child, #graph .slider').on('mousewheel', function(e) {
-        if (e.originalEvent.wheelDelta < 0) goForward()
-        else if (e.originalEvent.wheelDelta > 0) goBack()
+        if (e.wheelDelta < 0) goForward()
+        else if (e.wheelDelta > 0) goBack()
     })
 })
 

--- a/view/index.js
+++ b/view/index.js
@@ -1633,32 +1633,32 @@ function commitPreferences() {
 
 function sendGTPCommand(command, ignoreBlocked, callback) {
     if (!getEngineController()) {
-        $('#console form:last-child input')[0].value = ''
+        $('#console form:last-child input').val('')
         return
     }
 
     var controller = getEngineController()
-    var container = $('#console .inner')[0]
-    var oldform = container.find('form:last-child')
-    var $form = oldform.clone(true, true)
+    var $container = $('#console .inner')
+    var $oldform = $container.find('form:last-child')
+    var $form = $oldform.clone(true, true)
     var $pre = $('<pre/>').text(' ')
 
     $form.find('input').val('')
-    oldform.addClass('waiting').find('input').value = command.toString()
-    container.append($pre).append($form)
+    $oldform.addClass('waiting').find('input').val(command.toString())
+    $container.append($pre).append($form)
     if (getShowLeftSidebar()) $form.find('input').focus()
 
     // Cleanup
     var $forms = $('#console .inner form')
     if ($forms.length > setting.get('console.max_history_count')) {
-        $forms.eq(0).nextAll('pre').remove()
+        $forms.eq(0).siblings('pre').remove()
         $forms.eq(0).remove()
     }
 
     var listener = function(response, c) {
         $pre.html(response.toHtml())
         wireLinks($pre)
-        oldform.removeClass('waiting')
+        $oldform.removeClass('waiting')
         if (callback) callback(response)
 
         // Update scrollbars

--- a/view/index.js
+++ b/view/index.js
@@ -595,7 +595,7 @@ function prepareGameInfo() {
     })
 
     $('#info section img.menu').on('click', function() {
-        var el = this
+        var $el = $(this)
 
         function selectEngine(engine, i) {
             var currentIndex = $(this).data('engineindex')
@@ -606,7 +606,7 @@ function prepareGameInfo() {
             $(this).data('engineindex', i)
 
             if (engine) {
-                var els = $('#info').find('section .menu')
+                var els = $('#info section .menu').get()
                 var other = els[0] == this ? els[1] : els[0]
                 if (other) selectEngine.call(other, null, -1)
 
@@ -617,7 +617,7 @@ function prepareGameInfo() {
             }
         }
 
-        openEnginesMenu(el, selectEngine.bind(el))
+        openEnginesMenu($el, selectEngine.bind($el.get(0)))
     })
 
     // Prepare date input

--- a/view/index.js
+++ b/view/index.js
@@ -218,7 +218,7 @@ function setBoard(board) {
             types.forEach(function(x) {
                 if (li.hasClass(x)) li.removeClass(x)
             })
-            li.getElement('.stone span').set('title', '')
+            li.getElement('.stone span').attr('title', '')
 
             // Add markups
 
@@ -227,7 +227,7 @@ function setBoard(board) {
                 var type = markup[0], label = markup[1]
 
                 if (type != '') li.addClass(type)
-                if (label != '') li.getElement('.stone span').set('title', label)
+                if (label != '') li.getElement('.stone span').attr('title', label)
                 li.toggleClass('smalllabel', label.length >= 3)
             }
 
@@ -286,11 +286,11 @@ function setScoringMethod(method) {
         var tr = $('#score tbody tr' + (sign < 0 ? ':last-child' : ''))[0]
         var tds = tr.getElements('td')
 
-        tds[4].set('text', 0)
+        tds[4].attr('text', 0)
 
         for (var i = 0; i <= 3; i++) {
             if (tds[i].hasClass('disabled') || isNaN(+tds[i].get('text'))) continue
-            tds[4].set('text', +tds[4].get('text') + +tds[i].get('text'))
+            tds[4].attr('text', +tds[4].get('text') + +tds[i].get('text'))
         }
     }
 
@@ -299,7 +299,7 @@ function setScoringMethod(method) {
     var result = diff > 0 ? 'B+' :  diff < 0 ? 'W+' : 'Draw'
     if (diff != 0) result = result + Math.abs(diff)
 
-    $('#score .result').set('text', result)
+    $('#score .result').attr('text', result)
 }
 
 function getKomi() {
@@ -325,7 +325,7 @@ function setUndoable(undoable, tooltip) {
         var position = gametree.getLevel.apply(null, getCurrentTreePosition())
         if (!tooltip) tooltip = 'Undo'
 
-        $('#bar header .undo').set('title', tooltip)
+        $('#bar header .undo').attr('title', tooltip)
         document.body
             .addClass('undoable')
             .data('undodata-root', rootTree)
@@ -369,7 +369,7 @@ function getEmptyGameTree() {
  */
 
 function loadSettings() {
-    $('#head link.userstyle').set('href', setting.stylesPath)
+    $('#head link.userstyle').attr('href', setting.stylesPath)
 
     $('#goban').toggleClass('fuzzy', setting.get('view.fuzzy_stone_placement'))
     $('#goban').toggleClass('animation', setting.get('view.animated_stone_placement'))
@@ -397,11 +397,11 @@ function prepareEditTools() {
         } else if (this.getParent().hasClass('stone-tool')) {
             var img = this.getElement('img')
             var black = img.get('src') == '../img/edit/stone_1.svg'
-            img.set('src', black ? '../img/edit/stone_-1.svg' : '../img/edit/stone_1.svg')
+            img.attr('src', black ? '../img/edit/stone_-1.svg' : '../img/edit/stone_1.svg')
         } else if (this.getParent().hasClass('line-tool')) {
             var img = this.getElement('img')
             var line = img.get('src') == '../img/edit/line.svg'
-            img.set('src', line ? '../img/edit/arrow.svg' : '../img/edit/line.svg')
+            img.attr('src', line ? '../img/edit/arrow.svg' : '../img/edit/line.svg')
         }
     })
 }
@@ -720,7 +720,7 @@ function prepareGameInfo() {
 
     // Handle size inputs
 
-    $('#info input[name^="size-"]').set('placeholder', setting.get('game.default_board_size'))
+    $('#info input[name^="size-"]').attr('placeholder', setting.get('game.default_board_size'))
 
     $('#info input[name="size-width"]').on('focus', function() {
         $(this).data('link', this.value == this.getParent().getNext('input[name="size-height"]').value)
@@ -1656,7 +1656,7 @@ function sendGTPCommand(command, ignoreBlocked, callback) {
     }
 
     var listener = function(response, c) {
-        pre.set('html', response.toHtml())
+        pre.attr('html', response.toHtml())
         wireLinks(pre)
         oldform.removeClass('waiting')
         if (callback) callback(response)
@@ -2124,6 +2124,6 @@ $(window).on('resize', function() {
     if (win.isMaximized() || win.isMinimized() || win.isFullScreen()) return
 
     setting
-    .set('window.width', $('body').width())
-    .set('window.height', $('body').height())
+    .attr('window.width', $('body').width())
+    .attr('window.height', $('body').height())
 })

--- a/view/index.js
+++ b/view/index.js
@@ -1647,7 +1647,7 @@ function sendGTPCommand(command, ignoreBlocked, callback) {
     }
 
     var listener = function(response, c) {
-        $pre.attr('html', response.toHtml())
+        $pre.html(response.toHtml())
         wireLinks($pre)
         oldform.removeClass('waiting')
         if (callback) callback(response)

--- a/view/index.js
+++ b/view/index.js
@@ -460,7 +460,7 @@ function prepareSlider() {
         if (e.event.buttons != 1 || !$slider.data('mousedown'))
             return
 
-        var percentage = (e.event.clientY - $slider.getPosition().y) / $slider.getSize().y
+        var percentage = (e.event.clientY - $slider.position().top) / $slider.innerHeight()
         changeSlider(percentage)
         document.onselectstart = function() { return false }
     }
@@ -473,7 +473,7 @@ function prepareSlider() {
     }).on('touchstart', function() {
         this.addClass('active')
     }).on('touchmove', function(e) {
-        var percentage = (e.client.y - $slider.getPosition().y) / $slider.getSize().y
+        var percentage = (e.client.y - $slider.position().top) / $slider.innerHeight()
         changeSlider(percentage)
     }).on('touchend', function() {
         this.removeClass('active')
@@ -634,8 +634,8 @@ function prepareGameInfo() {
     var adjustPosition = function(pikaday) {
         pikaday.el
         .css('position', 'absolute')
-        .css('left', dateInput.getPosition().x)
-        .css('top', dateInput.getPosition().y - pikaday.el.getSize().y)
+        .css('left', dateInput.position().left)
+        .css('top', dateInput.position().top - pikaday.el.innerHeight())
     }
     var markDates = function(pikaday) {
         var dates = (sgf.string2dates(dateInput.value) || []).filter(function(x) {

--- a/view/index.js
+++ b/view/index.js
@@ -489,7 +489,7 @@ function prepareSlider() {
 
     $('#sidebar .slider a').on('mousedown', function() {
         $(this).data('mousedown', true)
-        startAutoScroll(this.hasClass('next') ? 1 : -1)
+        startAutoScroll($(this).hasClass('next') ? 1 : -1)
     })
 
     document.on('mouseup', function() {

--- a/view/index.js
+++ b/view/index.js
@@ -1450,7 +1450,7 @@ function updateCommentText() {
         return [null, null]
     })()))
 
-    $('#properties .gm-scroll-view').eq(0).scrollTop(0)
+    $('#properties .gm-scroll-view').scrollTop(0)
     $('#properties').data('scrollbar').update()
 }
 
@@ -1467,8 +1467,9 @@ function updateAreaMap(useEstimateMap) {
     var map = useEstimateMap ? board.getAreaEstimateMap() : board.getAreaMap()
 
     $('#goban .row li').get().forEach(function(li) {
-        $(li).removeClass('area_-1').removeClass('area_0').removeClass('area_1')
-            .addClass('area_' + map[$(li).data('vertex')])
+        $(li)
+        .removeClass('area_-1').removeClass('area_0').removeClass('area_1')
+        .addClass('area_' + map[$(li).data('vertex')])
     })
 
     if (!useEstimateMap) {
@@ -1480,8 +1481,9 @@ function updateAreaMap(useEstimateMap) {
         }
     }
 
-    $('#goban').data('areamap', map)
-        .data('finalboard', board)
+    $('#goban')
+    .data('areamap', map)
+    .data('finalboard', board)
 }
 
 function commitCommentText() {
@@ -1502,7 +1504,7 @@ function commitCommentText() {
 
 function commitGameInfo() {
     var rootNode = getRootTree().nodes[0]
-    var info = $('#info')
+    var $info = $('#info')
 
     var data = {
         'rank_1': 'BR',
@@ -1516,7 +1518,7 @@ function commitGameInfo() {
     }
 
     for (var name in data) {
-        var value = info.find('input[name="' + name + '"]').val().trim()
+        var value = $info.find('input[name="' + name + '"]').val().trim()
         rootNode[data[name]] = [value]
         if (value == '') delete rootNode[data[name]]
     }
@@ -1532,14 +1534,14 @@ function commitGameInfo() {
 
     // Handle komi
 
-    var komi = +info.find('input[name="komi"]').val()
+    var komi = +$info.find('input[name="komi"]').val()
     if (isNaN(komi)) komi = 0
     rootNode.KM = ['' + komi]
 
     // Handle size
 
     var size = ['width', 'height'].map(function(x) {
-        var num = parseFloat(info.find('input[name="size-' + x + '"]').val())
+        var num = parseFloat($info.find('input[name="size-' + x + '"]').val())
         if (isNaN(num)) num = setting.get('game.default_board_size')
         return Math.min(Math.max(num, 3), 25)
     })
@@ -1549,10 +1551,10 @@ function commitGameInfo() {
 
     // Handle handicap stones
 
-    var handicapInput = info.find('select[name="handicap"]')
-    var handicap = handicapInput.selectedIndex
+    var $handicapInput = $info.find('select[name="handicap"]')
+    var handicap = $handicapInput.get(0).selectedIndex
 
-    if (!handicapInput.disabled) {
+    if (!$handicapInput.get(0).disabled) {
         setCurrentTreePosition(getRootTree(), 0)
 
         if (handicap == 0) {
@@ -1574,7 +1576,7 @@ function commitGameInfo() {
 
     // Start engine
 
-    if (!$('#info').hasClass('disabled')) {
+    if (!$info.hasClass('disabled')) {
         var engines = setting.getEngines()
         var indices = $('#info section .menu').map(function(x) { return x.data('engineindex') })
         var max = Math.max.apply(null, indices)

--- a/view/index.js
+++ b/view/index.js
@@ -439,7 +439,7 @@ function prepareGameGraph() {
 }
 
 function prepareSlider() {
-    var $slider = $('#sidebar .slider .inner')
+    var $slider = $('#sidebar .slider .inner').eq(0)
     Element.NativeEvents.touchstart = 2
     Element.NativeEvents.touchmove = 2
     Element.NativeEvents.touchend = 2
@@ -468,15 +468,15 @@ function prepareSlider() {
     $slider.on('mousedown', function(e) {
         if (e.event.buttons != 1) return
 
-        this.data('mousedown', true).addClass('active')
+        $(this).data('mousedown', true).addClass('active')
         mouseMoveHandler(e)
     }).on('touchstart', function() {
-        this.addClass('active')
+        $(this).addClass('active')
     }).on('touchmove', function(e) {
         var percentage = (e.client.y - $slider.position().top) / $slider.innerHeight()
         changeSlider(percentage)
     }).on('touchend', function() {
-        this.removeClass('active')
+        $(this).removeClass('active')
     })
 
     $(document).on('mouseup', function() {
@@ -488,7 +488,7 @@ function prepareSlider() {
     // Prepare previous/next buttons
 
     $('#sidebar .slider a').on('mousedown', function() {
-        this.data('mousedown', true)
+        $(this).data('mousedown', true)
         startAutoScroll(this.hasClass('next') ? 1 : -1)
     })
 
@@ -530,8 +530,8 @@ function prepareConsole() {
         if ([40, 38, 9].indexOf(e.code) != -1) e.preventDefault()
         var inputs = $('#console form input')
 
-        if (this.data('index') == null) this.data('index', inputs.indexOf(this))
-        var i = this.data('index')
+        if ($(this).data('index') == null) $(this).data('index', inputs.indexOf(this))
+        var i = $(this).data('index')
         var length = inputs.length
 
         if ([38, 40].indexOf(e.code) != -1) {
@@ -544,7 +544,7 @@ function prepareConsole() {
             }
 
             this.value = i == length - 1 ? '' : inputs[i].value
-            this.data('index', i)
+            $(this).data('index', i)
         } else if (e.code == 9) {
             // Tab
             var tokens = this.value.split(' ')
@@ -584,13 +584,13 @@ function prepareGameInfo() {
 
     $('#info .currentplayer').on('click', function() {
         var data = $('#info section input[type="text"]').map(function(el) {
-            return el.get('value')
+            return el.val()
         })
 
-        $('#info section input[name="rank_1"]')[0].set('value', data[3])
-        $('#info section input[name="rank_-1"]')[0].set('value', data[0])
-        $('#info section input[name="name_1"]')[0].set('value', data[2])
-        $('#info section input[name="name_-1"]')[0].set('value', data[1])
+        $('#info section input[name="rank_1"]').eq(0).val(data[3])
+        $('#info section input[name="rank_-1"]').eq(0).val(data[0])
+        $('#info section input[name="name_1"]').eq(0).val(data[2])
+        $('#info section input[name="name_-1"]').eq(0).val(data[1])
 
         data = $('#info section .menu').map(function(el) {
             return [el.hasClass('active'), el.data('engineindex')]
@@ -606,19 +606,19 @@ function prepareGameInfo() {
         var el = this
 
         function selectEngine(engine, i) {
-            var currentIndex = this.data('engineindex')
+            var currentIndex = $(this).data('engineindex')
             if (currentIndex == null) currentIndex = -1
             if (i == currentIndex) return
 
-            this.getParent().getElement('input[name^="name_"]').set('value', engine ? engine.name : '')
-            this.data('engineindex', i)
+            this.getParent().getElement('input[name^="name_"]').val(engine ? engine.name : '')
+            $(this).data('engineindex', i)
 
             if (engine) {
                 var els = $('#info').getElements('section .menu')
                 var other = els[0] == this ? els[1] : els[0]
                 if (other) selectEngine.call(other, null, -1)
 
-                this.addClass('active')
+                $(this).addClass('active')
             } else {
                 $('#info').getElements('section .menu')
                 .removeClass('active')
@@ -723,9 +723,9 @@ function prepareGameInfo() {
     $('#info input[name^="size-"]').set('placeholder', setting.get('game.default_board_size'))
 
     $('#info input[name="size-width"]').on('focus', function() {
-        this.data('link', this.value == this.getParent().getNext('input[name="size-height"]').value)
+        $(this).data('link', this.value == this.getParent().getNext('input[name="size-height"]').value)
     }).on('input', function() {
-        if (!this.data('link')) return
+        if (!$(this).data('link')) return
         this.getParent().getNext('input[name="size-height"]').value = this.value
     })
 
@@ -1029,7 +1029,7 @@ function makeResign(sign) {
 
     showGameInfo()
     var player = sign > 0 ? 'W' : 'B'
-    $('#info input[name="result"]').set('value', player + '+Resign')
+    $('#info input[name="result"]').val(player + '+Resign')
 }
 
 function useTool(vertex, event) {
@@ -1518,7 +1518,7 @@ function commitGameInfo() {
     }
 
     for (var name in data) {
-        var value = info.getElement('input[name="' + name + '"]').get('value').trim()
+        var value = info.getElement('input[name="' + name + '"]').val().trim()
         rootNode[data[name]] = [value]
         if (value == '') delete rootNode[data[name]]
     }
@@ -1534,14 +1534,14 @@ function commitGameInfo() {
 
     // Handle komi
 
-    var komi = +info.getElement('input[name="komi"]').get('value')
+    var komi = +info.getElement('input[name="komi"]').val()
     if (isNaN(komi)) komi = 0
     rootNode.KM = ['' + komi]
 
     // Handle size
 
     var size = ['width', 'height'].map(function(x) {
-        var num = parseFloat(info.getElement('input[name="size-' + x + '"]').get('value'))
+        var num = parseFloat(info.getElement('input[name="size-' + x + '"]').val())
         if (isNaN(num)) num = setting.get('game.default_board_size')
         return Math.min(Math.max(num, 3), 25)
     })
@@ -1595,7 +1595,7 @@ function commitScore() {
     var result = $('#score .result').get('text')
 
     showGameInfo()
-    $('#info input[name="result"]').set('value', result)
+    $('#info input[name="result"]').val(result)
 
     setUndoable(false)
 }
@@ -1643,7 +1643,7 @@ function sendGTPCommand(command, ignoreBlocked, callback) {
     var form = oldform.clone().cloneEvents(oldform)
     var pre = new Element('pre', { text: ' ' })
 
-    form.getElement('input').set('value', '').cloneEvents(oldform.getElement('input'))
+    form.getElement('input').val('').cloneEvents(oldform.getElement('input'))
     oldform.addClass('waiting').getElement('input').value = command.toString()
     container.grab(pre).grab(form)
     if (getShowLeftSidebar()) form.getElement('input').focus()

--- a/view/index.js
+++ b/view/index.js
@@ -1,5 +1,5 @@
 var $ = require('jquery')
-var $sprint = require('sprint-js')
+var $$ = require('sprint-js')
 var fs = require('fs')
 var process = require('process')
 var remote = require('electron').remote
@@ -208,7 +208,7 @@ function setBoard(board) {
 
     for (var x = 0; x < board.width; x++) {
         for (var y = 0; y < board.height; y++) {
-            var $li = $sprint('#goban .pos_' + x + '-' + y)
+            var $li = $$('#goban .pos_' + x + '-' + y)
             var $span = $li.find('.stone span')
             var sign = board.arrangement[[x, y]]
             var types = ['ghost_1', 'ghost_-1', 'siblingghost_1', 'siblingghost_-1',
@@ -244,7 +244,7 @@ function setBoard(board) {
 
     board.ghosts.forEach(function(x) {
         var v = x[0], s = x[1], type = x[2]
-        var $li = $sprint('#goban .pos_' + v.join('-'))
+        var $li = $$('#goban .pos_' + v.join('-'))
 
         if (type == 'child') $li.addClass('ghost_' + s)
         else if (type == 'sibling') $li.addClass('siblingghost_' + s)
@@ -252,7 +252,7 @@ function setBoard(board) {
 
     // Add lines
 
-    $sprint('#goban hr').remove()
+    $$('#goban hr').remove()
 
     board.lines.forEach(function(line) {
         $('#goban').append(

--- a/view/index.js
+++ b/view/index.js
@@ -634,8 +634,8 @@ function prepareGameInfo() {
     var adjustPosition = function(pikaday) {
         $(pikaday.el)
         .css('position', 'absolute')
-        .css('left', $dateInput.position().left)
-        .css('top', $dateInput.position().top - $(pikaday.el).height())
+        .css('left', Math.round($dateInput.offset().left))
+        .css('top', Math.round($dateInput.offset().top - $(pikaday.el).height()))
     }
     var markDates = function(pikaday) {
         var dates = (sgf.string2dates($dateInput.val()) || []).filter(function(x) {

--- a/view/index.js
+++ b/view/index.js
@@ -189,7 +189,7 @@ function setSelectedTool(tool) {
     }
 
     $('#goban').data('edittool-data', null)
-    $('#edit .' + tool + '-tool a').fireEvent('click')
+    $('#edit .' + tool + '-tool a').trigger('click')
 }
 
 function getBoard() {
@@ -439,7 +439,7 @@ function prepareGameGraph() {
 }
 
 function prepareSlider() {
-    var slider = $('#sidebar .slider .inner')[0]
+    var $slider = $('#sidebar .slider .inner')
     Element.NativeEvents.touchstart = 2
     Element.NativeEvents.touchmove = 2
     Element.NativeEvents.touchend = 2
@@ -456,32 +456,34 @@ function prepareSlider() {
         updateSlider()
     }
 
-    slider.on('mousedown', function(e) {
+    var mouseMoveHandler = function(e) {
+        if (e.event.buttons != 1 || !$slider.data('mousedown'))
+            return
+
+        var percentage = (e.event.clientY - $slider.getPosition().y) / $slider.getSize().y
+        changeSlider(percentage)
+        document.onselectstart = function() { return false }
+    }
+
+    $slider.on('mousedown', function(e) {
         if (e.event.buttons != 1) return
 
         this.data('mousedown', true).addClass('active')
-        document.fireEvent('mousemove', e)
+        mouseMoveHandler(e)
     }).on('touchstart', function() {
         this.addClass('active')
     }).on('touchmove', function(e) {
-        var percentage = (e.client.y - slider.getPosition().y) / slider.getSize().y
+        var percentage = (e.client.y - $slider.getPosition().y) / $slider.getSize().y
         changeSlider(percentage)
     }).on('touchend', function() {
         this.removeClass('active')
     })
 
-    document.on('mouseup', function() {
-        slider.data('mousedown', false)
+    $(document).on('mouseup', function() {
+        $slider.data('mousedown', false)
             .removeClass('active')
         document.onselectstart = null
-    }).on('mousemove', function(e) {
-        if (e.event.buttons != 1 || !slider.data('mousedown'))
-            return
-
-        var percentage = (e.event.clientY - slider.getPosition().y) / slider.getSize().y
-        changeSlider(percentage)
-        document.onselectstart = function() { return false }
-    })
+    }).on('mousemove', mouseMoveHandler)
 
     // Prepare previous/next buttons
 

--- a/view/index.js
+++ b/view/index.js
@@ -259,7 +259,8 @@ function setBoard(board) {
 
     board.lines.forEach(function(line) {
         $('#goban').append(
-            new Element('hr', { class: line[2] ? 'arrow' : 'line' })
+            $('<hr/>')
+            .addClass(line[2] ? 'arrow' : 'line')
             .data('v1', line[0])
             .data('v2', line[1])
         )
@@ -1109,25 +1110,25 @@ function useTool(vertex, event) {
     } else if (tool == 'line' || tool == 'arrow') {
         // Check whether to remove a line
 
-        var hr = $('#goban').data('edittool-data')
+        var $hr = $('#goban').data('edittool-data')
 
-        if (hr) {
-            var v1 = hr.data('v1'), v2 = hr.data('v2')
+        if ($hr) {
+            var v1 = $hr.data('v1'), v2 = $hr.data('v2')
             var toDelete = $('#goban hr').get().filter(function(x) {
                 var w1 = $(x).data('v1'), w2 = $(x).data('v2')
-                var result = x != hr
+                var result = x != $hr.get(0)
                     && w1[0] == v1[0] && w1[1] == v1[1]
                     && w2[0] == v2[0] && w2[1] == v2[1]
 
-                if (tool == 'line' || $(x).hasClass('line')) result = result || x != hr
+                if (tool == 'line' || $(x).hasClass('line')) result = result || x != $hr.get(0)
                     && w1[0] == v2[0] && w1[1] == v2[1]
                     && w2[0] == v1[0] && w2[1] == v1[1]
 
                 return result
             })
 
-            if (toDelete.length != 0) hr.remove()
-            toDelete.remove()
+            if (toDelete.length != 0) $hr.remove()
+            $(toDelete).remove()
         }
 
         $('#goban').data('edittool-data', null)
@@ -1235,11 +1236,11 @@ function drawLine(vertex) {
     if (!vertex || !getEditMode() || tool != 'line' && tool != 'arrow') return
 
     if (!$('#goban').data('edittool-data')) {
-        var hr = new Element('hr', { class: tool }).data('v1', vertex).data('v2', vertex)
-        $('#goban').append(hr).data('edittool-data', hr)
+        var $hr = $('<hr/>').addClass(tool).data('v1', vertex).data('v2', vertex)
+        $('#goban').append($hr).data('edittool-data', $hr)
     } else {
-        var hr = $('#goban').data('edittool-data')
-        hr.data('v2', vertex)
+        var $hr = $('#goban').data('edittool-data')
+        $hr.data('v2', vertex)
     }
 
     updateBoardLines()
@@ -1640,24 +1641,24 @@ function sendGTPCommand(command, ignoreBlocked, callback) {
     var controller = getEngineController()
     var container = $('#console .inner')[0]
     var oldform = container.find('form:last-child')
-    var form = oldform.clone().cloneEvents(oldform)
-    var pre = new Element('pre', { text: ' ' })
+    var $form = oldform.clone(true, true)
+    var $pre = $('<pre/>').text(' ')
 
-    form.find('input').val('').cloneEvents(oldform.find('input'))
+    $form.find('input').val('')
     oldform.addClass('waiting').find('input').value = command.toString()
-    container.append(pre).append(form)
-    if (getShowLeftSidebar()) form.find('input').focus()
+    container.append($pre).append($form)
+    if (getShowLeftSidebar()) $form.find('input').focus()
 
     // Cleanup
     var forms = $('#console .inner form')
     if (forms.length > setting.get('console.max_history_count')) {
-        forms[0].getNext('pre').dispose()
-        forms[0].dispose()
+        forms[0].getNext('pre').remove()
+        forms[0].remove()
     }
 
     var listener = function(response, c) {
-        pre.attr('html', response.toHtml())
-        wireLinks(pre)
+        $pre.attr('html', response.toHtml())
+        wireLinks($pre)
         oldform.removeClass('waiting')
         if (callback) callback(response)
 

--- a/view/index.js
+++ b/view/index.js
@@ -217,7 +217,9 @@ function setBoard(board) {
 
             // Clean up
 
-            types.forEach(function(x) { $li.removeClass(x) })
+            types.forEach(function(x) {
+                if ($li.hasClass(x)) $li.removeClass(x)
+            })
 
             $span.attr('title', '')
 
@@ -235,7 +237,11 @@ function setBoard(board) {
             // Set stone image
 
             if ($li.hasClass('sign_' + sign)) continue
-            for (var i = -1; i <= 1; i++) $li.removeClass('sign_' + i)
+
+            for (var i = -1; i <= 1; i++) {
+                if ($li.hasClass('sign_' + i)) $li.removeClass('sign_' + i)
+            }
+
             $li.addClass('sign_' + sign)
         }
     }

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -208,7 +208,7 @@ function getPlayerName(sign) {
 
 function setPlayerName(sign, name, tooltip) {
     if (name.trim() == '') name = sign > 0 ? 'Black' : 'White'
-    $('#player_' + sign + ' .name')[0].attr('text', name).attr('title', tooltip)
+    $('#player_' + sign + ' .name')[0].text(name).attr('title', tooltip)
 }
 
 function getShowHotspot() {
@@ -227,9 +227,9 @@ function getCaptures() {
 }
 
 function setCaptures(captures) {
-    $('#player_-1 .captures')[0].attr('text', captures['-1'])
+    $('#player_-1 .captures')[0].text(captures['-1'])
         .css('opacity', captures['-1'] == 0 ? 0 : .7)
-    $('#player_1 .captures')[0].attr('text', captures['1'])
+    $('#player_1 .captures')[0].text(captures['1'])
         .css('opacity', captures['1'] == 0 ? 0 : .7)
 }
 
@@ -262,7 +262,7 @@ function getCommentTitle() {
 function setCommentTitle(text) {
     var input = $('#properties .edit .header input')[0]
 
-    $('#properties .inner .header span')[0].attr('text', text.trim() != '' ? text : getCurrentMoveInterpretation())
+    $('#properties .inner .header span')[0].text(text.trim() != '' ? text : getCurrentMoveInterpretation())
     if (input.val() != text) input.val(text)
 }
 
@@ -316,15 +316,15 @@ function setAnnotations(posstatus, posvalue, movestatus, movevalue) {
 }
 
 function getSliderValue() {
-    var span = $('#sidebar .slider .inner span')[0]
-    var value = parseFloat(span.css('top'))
-    var label = span.attr('text')
+    var $span = $('#sidebar .slider .inner span').eq(0)
+    var value = parseFloat($span.css('top'))
+    var label = $span.attr('text')
 
     return [value, label]
 }
 
 function setSliderValue(value, label) {
-    $('#sidebar .slider .inner span').css('top', value + '%').attr('text', label)
+    $('#sidebar .slider .inner span').css('top', value + '%').text(label)
 }
 
 function getFindMode() {
@@ -715,18 +715,21 @@ function addEngineItem(name, path, args) {
     if (!args) args = ''
 
     var $ul = $('#preferences .engines-list ul').eq(0)
-    var $li = $('<li/>').append($('<h3/>').append(
-        $('<input/>')
-        .attr('type', 'text')
-        .attr('placeholder', '(Unnamed engine)')
-        .val(name)
-    )).append(
+    var $li = $('<li/>').append(
+        $('<h3/>')
+        .append(
+            $('<input/>')
+            .attr('type', 'text')
+            .attr('placeholder', '(Unnamed engine)')
+            .val(name)
+        )
+    ).append(
         $('<p/>').append(
             $('<input/>')
             .attr('type', 'text')
             .attr('placeholder', 'Path')
             .val(path)
-        )).append(
+        ).append(
             $('<a class="browse"/>')
             .on('click', function() {
                 setIsBusy(true)
@@ -744,19 +747,19 @@ function addEngineItem(name, path, args) {
 
                 setIsBusy(false)
             })
-        }).append(
+        ).append(
             $('<img/>')
             .attr('src', '../node_modules/octicons/svg/file-directory.svg')
             .attr('title', 'Browse…')
             .attr('height', 14)
-        )))
+        )
     ).append(
         $('<p/>').append(
             $('<input/>')
             .attr('type', 'text')
             .attr('placeholder', 'No arguments')
             .attr('value', args)
-        ))
+        )
     ).append(
         $('<a class="remove"/>').on('click', function() {
             this.parents('li').eq(0).remove()
@@ -765,7 +768,7 @@ function addEngineItem(name, path, args) {
             $('img')
             .attr('src', '../node_modules/octicons/svg/x.svg')
             .attr('height', 14)
-        ))
+        )
     )
 
     $ul.append($li)
@@ -827,21 +830,21 @@ function readjustShifts(vertex) {
     }
 
     if (query && removeShifts) {
-        var el = $(query)
-        el.addClass('animate')
-        removeShifts.forEach(function(s) { el.removeClass('shift_' + s) })
-        setTimeout(function() { el.removeClass('animate') }, 200)
+        var $el = $(query)
+        $el.addClass('animate')
+        removeShifts.forEach(function(s) { $el.removeClass('shift_' + s) })
+        setTimeout(function() { $el.removeClass('animate') }, 200)
     }
 }
 
 function updateSidebarLayout() {
-    var container = $('#properties .gm-scroll-view')[0]
-    container.css('opacity', 0)
+    var $container = $('#properties .gm-scroll-view')
+    $container.css('opacity', 0)
 
     setTimeout(function() {
         $('#graph').data('sigma').renderers[0].resize().render()
         $('#properties').data('scrollbar').update()
-        container.css('opacity', 1)
+        $container.css('opacity', 1)
     }, 300)
 }
 
@@ -1418,11 +1421,11 @@ function showScore() {
         var tr = $('#score tbody tr' + (sign < 0 ? ':last-child' : ''))[0]
         var tds = tr.children('td')
 
-        tds[0].attr('text', score['area_' + sign])
-        tds[1].attr('text', score['territory_' + sign])
-        tds[2].attr('text', score['captures_' + sign])
-        if (sign < 0) tds[3].attr('text', getKomi())
-        tds[4].attr('text', 0)
+        tds[0].text(score['area_' + sign])
+        tds[1].text(score['territory_' + sign])
+        tds[2].text(score['captures_' + sign])
+        if (sign < 0) tds[3].text(getKomi())
+        tds[4].text(0)
 
         setScoringMethod(setting.get('scoring.method'))
     }
@@ -1489,13 +1492,13 @@ function showGameChooser(restoreScrollbarPos) {
         ))
 
         var $gamename = $li.find('span')
-        var $black = $li.find('.black').attr('text', gametree.getPlayerName(1, tree, 'Black'))
-        var $white = $li.find('.white').attr('text', gametree.getPlayerName(-1, tree, 'White'))
+        var $black = $li.find('.black').text(gametree.getPlayerName(1, tree, 'Black'))
+        var $white = $li.find('.white').text(gametree.getPlayerName(-1, tree, 'White'))
 
         if ('BR' in node) $black.attr('title', node.BR[0])
         if ('WR' in node) $white.attr('title', node.WR[0])
-        if ('GN' in node) $gamename.attr('text', node.GN[0]).attr('title', node.GN[0])
-        else if ('EV' in node) $gamename.attr('text', node.EV[0]).attr('title', node.EV[0])
+        if ('GN' in node) $gamename.text(node.GN[0]).attr('title', node.GN[0])
+        else if ('EV' in node) $gamename.text(node.EV[0]).attr('title', node.EV[0])
 
         $li.data('gametree', tree).find('div').on('click', function() {
             var link = this

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -1212,18 +1212,18 @@ function openCommentMenu() {
 
     menu = Menu.buildFromTemplate(template)
     var $el = $('#properties .edit .header img')
-    
+
     menu.popup(
         remote.getCurrentWindow(),
         Math.round($el.offset().left),
-        Math.round($el.offset().top + $el.height())
+        Math.round($el.offset().top + $el.innerHeight())
     )
 }
 
-function openEnginesMenu(element, callback) {
+function openEnginesMenu($element, callback) {
     if (!callback) callback = function() {}
 
-    var currentIndex = element.data('engineindex')
+    var currentIndex = $element.data('engineindex')
     if (currentIndex == null) currentIndex = -1
 
     var template = [{
@@ -1256,10 +1256,12 @@ function openEnginesMenu(element, callback) {
         }
     })
 
-    var coord = element.getCoordinates()
-
     menu = Menu.buildFromTemplate(template)
-    menu.popup(remote.getCurrentWindow(), Math.round(coord.left), Math.round(coord.bottom))
+    menu.popup(
+        remote.getCurrentWindow(),
+        Math.round($element.offset().left),
+        Math.round($element.offset().top + $element.innerHeight())
+    )
 }
 
 function openNodeMenu(tree, index, event) {
@@ -1280,7 +1282,7 @@ function openNodeMenu(tree, index, event) {
     menu.popup(remote.getCurrentWindow(), Math.round(event.clientX), Math.round(event.clientY))
 }
 
-function openGameMenu(element, event) {
+function openGameMenu($element, event) {
     var template = [
         {
             label: '&Remove Game',
@@ -1293,9 +1295,11 @@ function openGameMenu(element, event) {
                     ['Remove Game', 'Cancel'], 1
                 ) == 1) return
 
-                var index = element.parents('ol').eq(0).find('li div').indexOf(element)
-                trees.splice(index, 1)
+                var index = $element.parents('ol').eq(0)
+                .find('li div').get()
+                .indexOf($element.get(0))
 
+                trees.splice(index, 1)
                 setGameTrees(trees)
 
                 if (trees.length == 0) {
@@ -1317,7 +1321,7 @@ function openGameMenu(element, event) {
                     ['Remove Games', 'Cancel'], 1
                 ) == 1) return
 
-                setGameTrees([element.parents('li').eq(0).data('gametree')])
+                setGameTrees([$element.parents('li').eq(0).data('gametree')])
                 setGameIndex(0)
                 showGameChooser(true)
             }
@@ -1366,9 +1370,12 @@ function openAddGameMenu() {
     ]
 
     var menu = Menu.buildFromTemplate(template)
-    var button = $('#gamechooser').find('button[name="add"]')
-    var position = button.getPosition()
-    menu.popup(remote.getCurrentWindow(), Math.round(position.x), Math.round(position.y + button.innerHeight()))
+    var $button = $('#gamechooser').find('button[name="add"]')
+    menu.popup(
+        remote.getCurrentWindow(),
+        Math.round($button.offset().left),
+        Math.round($button.offset().top + $button.innerHeight())
+    )
 }
 
 /**
@@ -1380,7 +1387,7 @@ function showGameInfo() {
 
     var tree = getRootTree()
     var rootNode = tree.nodes[0]
-    var info = $('#info')
+    var $info = $('#info')
     var data = {
         'rank_1': 'BR',
         'rank_-1': 'WR',
@@ -1390,21 +1397,21 @@ function showGameInfo() {
         'result': 'RE'
     }
 
-    info.addClass('show').find('input[name="name_1"]').focus()
+    $info.addClass('show').find('input[name="name_1"]').focus()
 
     for (var key in data) {
         var value = data[key]
-        info.find('input[name="' + key + '"]').val(value in rootNode ? rootNode[value][0] : '')
+        $info.find('input[name="' + key + '"]').val(value in rootNode ? rootNode[value][0] : '')
     }
 
-    info.find('input[name="name_1"]').val(gametree.getPlayerName(1, tree, ''))
-    info.find('input[name="name_-1"]').val(gametree.getPlayerName(-1, tree, ''))
-    info.find('input[name="komi"]').val('KM' in rootNode ? +rootNode.KM[0] : '')
-    info.find('input[name="size-width"]').val(getBoard().width)
-    info.find('input[name="size-height"]').val(getBoard().height)
-    info.find('section .menu').removeClass('active').data('engineindex', -1)
+    $info.find('input[name="name_1"]').val(gametree.getPlayerName(1, tree, ''))
+    $info.find('input[name="name_-1"]').val(gametree.getPlayerName(-1, tree, ''))
+    $info.find('input[name="komi"]').val('KM' in rootNode ? +rootNode.KM[0] : '')
+    $info.find('input[name="size-width"]').val(getBoard().width)
+    $info.find('input[name="size-height"]').val(getBoard().height)
+    $info.find('section .menu').removeClass('active').data('engineindex', -1)
 
-    var handicap = info.find('select[name="handicap"]')
+    var handicap = $info.find('select[name="handicap"]')
     if ('HA' in rootNode) handicap.selectedIndex = Math.max(0, +rootNode.HA[0] - 1)
     else handicap.selectedIndex = 0
 
@@ -1413,8 +1420,8 @@ function showGameInfo() {
         || ['AB', 'AW', 'W', 'B'].some(function(x) { return x in rootNode })
 
     handicap.disabled = disabled
-    info.find('input[name^="size-"]').attr('disabled', disabled)
-    info.toggleClass('disabled', disabled)
+    $info.find('input[name^="size-"]').attr('disabled', disabled)
+    $info.toggleClass('disabled', disabled)
 }
 
 function closeGameInfo() {
@@ -1472,7 +1479,7 @@ function showGameChooser(restoreScrollbarPos) {
     if (restoreScrollbarPos == null)
         restoreScrollbarPos = true
 
-    var scrollbarPos = restoreScrollbarPos ? $('#gamechooser .gm-scroll-view')[0].scrollTop : 0
+    var scrollbarPos = restoreScrollbarPos ? $('#gamechooser .gm-scroll-view').scrollTop() : 0
 
     closeDrawers()
 
@@ -1518,7 +1525,7 @@ function showGameChooser(restoreScrollbarPos) {
             }, 500)
         }).on('mouseup', function(e) {
             if (e.button != 2) return
-            openGameMenu(this, e)
+            openGameMenu($(this), e)
         }).on('dragstart', function(e) {
             $('#gamechooser').data('dragging', $(this).parents('li').eq(0))
         })
@@ -1552,7 +1559,7 @@ function showGameChooser(restoreScrollbarPos) {
         if (!dragged || !afterli && !beforeli) return
 
         if (afterli) $(afterli).before(dragged)
-        if (beforeli) $(beforeli).append(dragged)
+        if (beforeli) $(beforeli).after(dragged)
 
         setGameTrees($('#gamechooser ol > li').get().map(function(x) {
             return $(x).data('gametree')

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -192,7 +192,7 @@ function setSidebarWidth(width) {
 }
 
 function getPropertiesHeight() {
-    return $('#properties').getSize().y * 100 / $('#sidebar').getSize().y
+    return $('#properties').innerHeight() * 100 / $('#sidebar').innerHeight()
 }
 
 function setPropertiesHeight(height) {
@@ -670,7 +670,7 @@ function prepareResizers() {
         } else if (initPosY) {
             var initY = initPosY[0], initHeight = initPosY[1]
             var newheight = Math.min(Math.max(
-                initHeight + (initY - e.event.screenY) * 100 / $('#sidebar').getSize().y,
+                initHeight + (initY - e.event.screenY) * 100 / $('#sidebar').innerHeight(),
                 setting.get('view.properties_minheight')
             ), 100 - setting.get('view.properties_minheight'))
 
@@ -954,8 +954,8 @@ function updateBoardLines() {
         var length = Math.sqrt(dx * dx + dy * dy)
 
         line.setStyles({
-            top: (pos1.y + li1.getSize().y / 2 + pos2.y + li2.getSize().y / 2) / 2 - 2,
-            left: (pos1.x + li1.getSize().x / 2 + pos2.x + li2.getSize().x / 2) / 2 - 2,
+            top: (pos1.y + li1.innerHeight() / 2 + pos2.y + li2.innerHeight() / 2) / 2 - 2,
+            left: (pos1.x + li1.innerWidth() / 2 + pos2.x + li2.innerWidth() / 2) / 2 - 2,
             marginLeft: -length / 2,
             width: length,
             transform: 'rotate(' + angle + 'deg)'
@@ -1012,10 +1012,10 @@ function showIndicator(vertex) {
     if (li.length == 0) return
     li = li[0]
 
-    $('#indicator').css('top', li.getPosition().y)
-        .css('left', li.getPosition().x)
-        .css('height', li.getSize().y)
-        .css('width', li.getSize().x)
+    $('#indicator').css('top', li.position().top)
+        .css('left', li.position().left)
+        .css('height', li.innerHeight())
+        .css('width', li.innerWidth())
         .data('vertex', vertex)
 }
 
@@ -1101,7 +1101,7 @@ function openHeaderMenu() {
     menu = Menu.buildFromTemplate(template)
     menu.popup(
         remote.getCurrentWindow(),
-        Math.round($('#headermenu').getPosition().x),
+        Math.round($('#headermenu').position().left),
         Math.round($('#header')[0].getCoordinates().top)
     )
 }
@@ -1357,7 +1357,7 @@ function openAddGameMenu() {
     var menu = Menu.buildFromTemplate(template)
     var button = $('#gamechooser').getElement('button[name="add"]')
     var position = button.getPosition()
-    menu.popup(remote.getCurrentWindow(), Math.round(position.x), Math.round(position.y + button.getSize().y))
+    menu.popup(remote.getCurrentWindow(), Math.round(position.x), Math.round(position.y + button.innerHeight()))
 }
 
 /**
@@ -1517,7 +1517,7 @@ function showGameChooser(restoreScrollbarPos) {
         if (!$('#gamechooser').data('dragging')) return
 
         var x = e.event.clientX
-        var middle = this.getPosition().x + this.getSize().x / 2
+        var middle = this.position().left + this.innerWidth() / 2
 
         if (x <= middle - 10 && !this.hasClass('insertleft')) {
             $('#gamechooser ol li').removeClass('insertleft').removeClass('insertright')

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -338,7 +338,7 @@ function setFindMode(pickMode) {
         if (pickMode != getFindMode()) closeDrawers()
         $('body').addClass('find')
 
-        var input = $('#find').find('input')
+        var input = $('#find input').get(0)
         input.focus()
         input.select()
     } else {
@@ -349,11 +349,11 @@ function setFindMode(pickMode) {
 }
 
 function getFindText() {
-    return $('#find').find('input').value
+    return $('#find input').val()
 }
 
 function setFindText(text) {
-    $('#find').find('input').value = text
+    $('#find input').val(text)
 }
 
 function getEditMode() {
@@ -433,7 +433,7 @@ function setIndicatorVertex(vertex) {
 }
 
 function setPreferencesTab(tab) {
-    $('#preferences .tabs')[0]
+    $('#preferences .tabs')
         .find('.current')
         .removeClass('current')
         .parent()
@@ -441,11 +441,11 @@ function setPreferencesTab(tab) {
         .parent()
         .addClass('current')
 
-    var form = $('#preferences form')[0]
-    form.className = tab
+    var $form = $('#preferences form')
+    $form.attr('class', tab)
 
     if (tab == 'engines')
-        $('#preferences .engines-list')[0].data('scrollbar').update()
+        $('#preferences .engines-list').data('scrollbar').update()
 }
 
 function getRepresentedFilename() {
@@ -615,7 +615,7 @@ function prepareScrollbars() {
 function prepareResizers() {
     $('.verticalresizer').on('mousedown', function(e) {
         if (e.button != 0) return
-        $(this).parent().data('initposx', [e.screenX, parseFloat($(this).parent().width())])
+        $(this).parent().data('initposx', [e.screenX, parseFloat($(this).parent().css('width'))])
     })
 
     $('#sidebar .horizontalresizer').on('mousedown', function(e) {
@@ -688,14 +688,14 @@ function prepareGameChooser() {
         var value = this.value
 
         $('#gamechooser .games-list li:not(.add)').get().forEach(function(li) {
-            if ($(li).children('span').some(function(span) {
-                return span.text().toLowerCase().indexOf(value.toLowerCase()) >= 0
+            if ($(li).find('span').get().some(function(span) {
+                return $(span).text().toLowerCase().indexOf(value.toLowerCase()) >= 0
             })) $(li).removeClass('hide')
             else $(li).addClass('hide')
         })
 
-        var gamesList = $('#gamechooser .games-list')[0]
-        gamesList.data('scrollbar').update()
+        var $gamesList = $('#gamechooser .games-list')
+        $gamesList.data('scrollbar').update()
     })
 }
 
@@ -741,19 +741,20 @@ function addEngineItem(name, path, args) {
                 })
 
                 if (result) {
-                    this.parents('li').eq(0)
-                        .find('h3 + p input')
-                        .val(result[0])
-                        .focus()
+                    $(this).parents('li').eq(0)
+                    .find('h3 + p input')
+                    .val(result[0])
+                    .focus()
                 }
 
                 setIsBusy(false)
             })
-        ).append(
-            $('<img/>')
-            .attr('src', '../node_modules/octicons/svg/file-directory.svg')
-            .attr('title', 'Browse…')
-            .attr('height', 14)
+            .append(
+                $('<img/>')
+                .attr('src', '../node_modules/octicons/svg/file-directory.svg')
+                .attr('title', 'Browse…')
+                .attr('height', 14)
+            )
         )
     ).append(
         $('<p/>').append(
@@ -764,7 +765,7 @@ function addEngineItem(name, path, args) {
         )
     ).append(
         $('<a class="remove"/>').on('click', function() {
-            this.parents('li').eq(0).remove()
+            $(this).parents('li').eq(0).remove()
             $('#preferences .engines-list')[0].data('scrollbar').update()
         }).append(
             $('<img/>')
@@ -1038,7 +1039,7 @@ function clearConsole() {
 }
 
 function wireLinks($container) {
-    $container.children('a').on('click', function() {
+    $container.find('a').on('click', function() {
         if ($(this).hasClass('external'))  {
             if (!shell) {
                 this.target = '_blank'
@@ -1058,7 +1059,7 @@ function wireLinks($container) {
         return false
     })
 
-    $container.children('.coord').on('mouseenter', function() {
+    $container.find('.coord').on('mouseenter', function() {
         var v = getBoard().coord2vertex($(this).text())
         showIndicator(v)
     }).on('mouseleave', function() {
@@ -1288,7 +1289,7 @@ function openGameMenu(element, event) {
                     ['Remove Game', 'Cancel'], 1
                 ) == 1) return
 
-                var index = element.parents('ol').eq(0).children('li div').indexOf(element)
+                var index = element.parents('ol').eq(0).find('li div').indexOf(element)
                 trees.splice(index, 1)
 
                 setGameTrees(trees)
@@ -1397,7 +1398,7 @@ function showGameInfo() {
     info.find('input[name="komi"]').val('KM' in rootNode ? +rootNode.KM[0] : '')
     info.find('input[name="size-width"]').val(getBoard().width)
     info.find('input[name="size-height"]').val(getBoard().height)
-    info.children('section .menu').removeClass('active').data('engineindex', -1)
+    info.find('section .menu').removeClass('active').data('engineindex', -1)
 
     var handicap = info.find('select[name="handicap"]')
     if ('HA' in rootNode) handicap.selectedIndex = Math.max(0, +rootNode.HA[0] - 1)
@@ -1408,7 +1409,7 @@ function showGameInfo() {
         || ['AB', 'AW', 'W', 'B'].some(function(x) { return x in rootNode })
 
     handicap.disabled = disabled
-    info.children('input[name^="size-"]').attr('disabled', disabled)
+    info.find('input[name^="size-"]').attr('disabled', disabled)
     info.toggleClass('disabled', disabled)
 }
 
@@ -1424,7 +1425,7 @@ function showScore() {
 
     for (var sign = -1; sign <= 1; sign += 2) {
         var $tr = $('#score tbody tr' + (sign < 0 ? ':last-child' : ''))
-        var $tds = $tr.children('td')
+        var $tds = $tr.find('td')
 
         $tds.eq(0).text(score['area_' + sign])
         $tds.eq(1).text(score['territory_' + sign])

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -970,8 +970,8 @@ function resizeBoard() {
     var board = getBoard()
     if (!board) return
 
-    var outerWidth = $('#main').outerWidth()
-    var outerHeight = $('#main').outerHeight()
+    var outerWidth = $('main').width()
+    var outerHeight = $('main').height()
     var boardWidth = board.width
     var boardHeight = board.height
     var width = helper.floorEven(outerWidth - $('#goban').outerWidth() + $('#goban').width())

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -99,7 +99,7 @@ function setShowLeftSidebar(show) {
     // Update scrollbars
     var $view = $('#console .gm-scroll-view')
     $view.scrollTop($view.get(0).scrollHeight)
-    $view.find('form:last-child input').focus()
+    $view.find('form:last-child input').get(0).focus()
     $('#console').data('scrollbar').update()
 }
 
@@ -744,7 +744,7 @@ function addEngineItem(name, path, args) {
                     $(this).parents('li').eq(0)
                     .find('h3 + p input')
                     .val(result[0])
-                    .focus()
+                    .get(0).focus()
                 }
 
                 setIsBusy(false)
@@ -1028,8 +1028,8 @@ function showIndicator(vertex) {
 
     $('#indicator').css('top', $li.offset().top)
     .css('left', $li.offset().left)
-    .css('height', $li.innerHeight())
-    .css('width', $li.innerWidth())
+    .css('height', $li.height())
+    .css('width', $li.width())
     .data('vertex', vertex)
 }
 
@@ -1042,7 +1042,7 @@ function hideIndicator() {
 
 function clearConsole() {
     $('#console .inner pre, #console .inner form:not(:last-child)').remove()
-    $('#console .inner form:last-child input').eq(0).val('').focus()
+    $('#console .inner form:last-child input').eq(0).val('').get(0).focus()
     $('#console').data('scrollbar').update()
 }
 
@@ -1405,7 +1405,7 @@ function showGameInfo() {
         'result': 'RE'
     }
 
-    $info.addClass('show').find('input[name="name_1"]').focus()
+    $info.addClass('show').find('input[name="name_1"]').get(0).focus()
 
     for (var key in data) {
         var value = data[key]
@@ -1491,7 +1491,7 @@ function showGameChooser(restoreScrollbarPos) {
 
     closeDrawers()
 
-    $('#gamechooser > input').eq(0).val('').focus()
+    $('#gamechooser > input').eq(0).val('').get(0).focus()
     $('#gamechooser ol').eq(0).empty()
 
     var trees = getGameTrees()
@@ -1544,7 +1544,7 @@ function showGameChooser(restoreScrollbarPos) {
         if (!$('#gamechooser').data('dragging')) return
 
         var x = e.clientX
-        var middle = $(this).position().left + $(this).innerWidth() / 2
+        var middle = $(this).position().left + $(this).width() / 2
 
         if (x <= middle - 10 && !$(this).hasClass('insertleft')) {
             $('#gamechooser ol li').removeClass('insertleft').removeClass('insertright')

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -863,10 +863,10 @@ function buildBoard() {
             var vertex = [x, y]
             var $img = $('<img/>').attr('src', '../img/goban/stone_0.svg')
             var $li = $('<li/>')
-                .data('vertex', vertex)
-                .addClass('pos_' + x + '-' + y)
-                .addClass('shift_' + Math.floor(Math.random() * 9))
-                .addClass('random_' + Math.floor(Math.random() * 5))
+            .data('vertex', vertex)
+            .addClass('pos_' + x + '-' + y)
+            .addClass('shift_' + Math.floor(Math.random() * 9))
+            .addClass('random_' + Math.floor(Math.random() * 5))
 
             if (hoshi.some(function(v) { return helper.equals(v, vertex) }))
                 $li.addClass('hoshi')
@@ -1018,8 +1018,8 @@ function showIndicator(vertex) {
 
     if ($li.length == 0) return
 
-    $('#indicator').css('top', $li.position().top)
-    .css('left', $li.position().left)
+    $('#indicator').css('top', $li.offset().top)
+    .css('left', $li.offset().left)
     .css('height', $li.innerHeight())
     .css('width', $li.innerWidth())
     .data('vertex', vertex)

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -1434,7 +1434,7 @@ function showGameInfo() {
     $info.find('input[name="size-height"]').val(getBoard().height)
     $info.find('section .menu').removeClass('active').data('engineindex', -1)
 
-    var handicap = $info.find('select[name="handicap"]')
+    var handicap = $info.find('select[name="handicap"]').get(0)
     if ('HA' in rootNode) handicap.selectedIndex = Math.max(0, +rootNode.HA[0] - 1)
     else handicap.selectedIndex = 0
 
@@ -1442,8 +1442,7 @@ function showGameInfo() {
         || tree.subtrees.length > 0
         || ['AB', 'AW', 'W', 'B'].some(function(x) { return x in rootNode })
 
-    handicap.disabled = disabled
-    $info.find('input[name^="size-"]').attr('disabled', disabled)
+    $info.find('input[name^="size-"]').add(handicap).prop('disabled', disabled)
     $info.toggleClass('disabled', disabled)
 }
 

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -715,18 +715,18 @@ function addEngineItem(name, path, args) {
     if (!args) args = ''
 
     var ul = $('#preferences .engines-list ul')[0]
-    var li = new Element('li').grab(new Element('h3').grab(
+    var li = new Element('li').append(new Element('h3').append(
         new Element('input', {
             type: 'text',
             placeholder: '(Unnamed engine)',
             value: name
         })
-    )).grab(
-        new Element('p').grab(new Element('input', {
+    )).append(
+        new Element('p').append(new Element('input', {
             type: 'text',
             placeholder: 'Path',
             value: path
-        })).grab(new Element('a.browse', {
+        })).append(new Element('a.browse', {
             events: {
                 click: function() {
                     setIsBusy(true)
@@ -745,18 +745,18 @@ function addEngineItem(name, path, args) {
                     setIsBusy(false)
                 }
             }
-        }).grab(new Element('img', {
+        }).append(new Element('img', {
             src: '../node_modules/octicons/svg/file-directory.svg',
             title: 'Browse…',
             height: 14
         })))
-    ).grab(
-        new Element('p').grab(new Element('input', {
+    ).append(
+        new Element('p').append(new Element('input', {
             type: 'text',
             placeholder: 'No arguments',
             value: args
         }))
-    ).grab(
+    ).append(
         new Element('a.remove', {
             events: {
                 click: function() {
@@ -764,13 +764,13 @@ function addEngineItem(name, path, args) {
                     $('#preferences .engines-list')[0].data('scrollbar').update()
                 }
             }
-        }).grab(new Element('img', {
+        }).append(new Element('img', {
             src: '../node_modules/octicons/svg/x.svg',
             height: 14
         }))
     )
 
-    ul.grab(li)
+    ul.append(li)
     li.find('h3 input').focus()
 
     var enginesScrollbar = $('#preferences .engines-list')[0].data('scrollbar')
@@ -907,7 +907,7 @@ function buildBoard() {
                 .on('mousedown', function() {
                     $('#goban').data('mousedown', true)
                 })
-                .grab(new Element('div.paint'))
+                .append(new Element('div.paint'))
             )
         }
 
@@ -928,7 +928,7 @@ function buildBoard() {
 
     var goban = $('#goban div')[0]
     goban.empty().adopt(rows, coordx, coordy)
-    goban.grab(coordx.clone(), 'top').grab(coordy.clone(), 'top')
+    goban.append(coordx.clone(), 'top').append(coordy.clone(), 'top')
 
     resizeBoard()
 
@@ -1481,12 +1481,12 @@ function showGameChooser(restoreScrollbarPos) {
         var svg = board.getSvg(setting.get('gamechooser.thumbnail_size'))
         var node = tree.nodes[0]
 
-        $('#gamechooser ol')[0].grab(li.grab(
+        $('#gamechooser ol')[0].append(li.append(
             new Element('div', { draggable: true })
-            .grab(new Element('span'))
-            .grab(svg)
-            .grab(new Element('span.black', { text: 'Black' }))
-            .grab(new Element('span.white', { text: 'White' }))
+            .append(new Element('span'))
+            .append(svg)
+            .append(new Element('span.black', { text: 'Black' }))
+            .append(new Element('span.white', { text: 'White' }))
         ))
 
         var gamename = li.find('span')
@@ -1532,15 +1532,15 @@ function showGameChooser(restoreScrollbarPos) {
         var dragged = $(this).data('dragging')
         $(this).data('dragging', null)
 
-        var lis = $('#gamechooser ol li')
-        var afterli = lis.filter(function(x) { return x.hasClass('insertleft') })[0]
-        var beforeli = lis.filter(function(x) { return x.hasClass('insertright') })[0]
-        lis.removeClass('insertleft').removeClass('insertright')
+        var $lis = $('#gamechooser ol li')
+        var afterli = $lis.get().filter(function(x) { return $(x).hasClass('insertleft') })[0]
+        var beforeli = $lis.get().filter(function(x) { return $(x).hasClass('insertright') })[0]
+        $lis.removeClass('insertleft').removeClass('insertright')
 
         if (!dragged || !afterli && !beforeli) return
 
-        if (afterli) afterli.grab(dragged, 'before')
-        if (beforeli) beforeli.grab(dragged, 'after')
+        if (afterli) $(afterli).before(dragged)
+        if (beforeli) $(beforeli).append(dragged)
 
         setGameTrees($('#gamechooser ol > li').map(function(x) {
             return x.data('gametree')
@@ -1552,7 +1552,7 @@ function showGameChooser(restoreScrollbarPos) {
 
     $('#gamechooser').addClass('show')
     $(window).trigger('resize')
-    $('#gamechooser .gm-scroll-view')[0].scrollTo(0, scrollbarPos)
+    $('#gamechooser .gm-scroll-view').get(0).scrollTo(0, scrollbarPos)
 }
 
 function closeGameChooser() {

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -208,7 +208,7 @@ function getPlayerName(sign) {
 
 function setPlayerName(sign, name, tooltip) {
     if (name.trim() == '') name = sign > 0 ? 'Black' : 'White'
-    $('#player_' + sign + ' .name')[0].set('text', name).set('title', tooltip)
+    $('#player_' + sign + ' .name')[0].attr('text', name).attr('title', tooltip)
 }
 
 function getShowHotspot() {
@@ -227,9 +227,9 @@ function getCaptures() {
 }
 
 function setCaptures(captures) {
-    $('#player_-1 .captures')[0].set('text', captures['-1'])
+    $('#player_-1 .captures')[0].attr('text', captures['-1'])
         .css('opacity', captures['-1'] == 0 ? 0 : .7)
-    $('#player_1 .captures')[0].set('text', captures['1'])
+    $('#player_1 .captures')[0].attr('text', captures['1'])
         .css('opacity', captures['1'] == 0 ? 0 : .7)
 }
 
@@ -238,7 +238,7 @@ function getCurrentPlayer() {
 }
 
 function setCurrentPlayer(sign) {
-    $('#.currentplayer').set('src', sign > 0 ? '../img/ui/blacktoplay.svg' : '../img/ui/whitetoplay.svg')
+    $('#.currentplayer').attr('src', sign > 0 ? '../img/ui/blacktoplay.svg' : '../img/ui/whitetoplay.svg')
 }
 
 function getCommentText() {
@@ -251,7 +251,7 @@ function setCommentText(text) {
     var textarea = $('#properties textarea')[0]
 
     if (textarea.val() != text) textarea.val(text)
-    container.set('html', html)
+    container.attr('html', html)
     wireLinks(container)
 }
 
@@ -262,7 +262,7 @@ function getCommentTitle() {
 function setCommentTitle(text) {
     var input = $('#properties .edit .header input')[0]
 
-    $('#properties .inner .header span')[0].set('text', text.trim() != '' ? text : getCurrentMoveInterpretation())
+    $('#properties .inner .header span')[0].attr('text', text.trim() != '' ? text : getCurrentMoveInterpretation())
     if (input.val() != text) input.val(text)
 }
 
@@ -276,17 +276,17 @@ function setAnnotations(posstatus, posvalue, movestatus, movevalue) {
     else header.addClass('movestatus')
 
     if (movestatus == -1)
-        img.set('src', '../img/ui/badmove.svg')
-            .set('alt', 'Bad move')
+        img.attr('src', '../img/ui/badmove.svg')
+            .attr('alt', 'Bad move')
     else if (movestatus == 0)
-        img.set('src', '../img/ui/doubtfulmove.svg')
-            .set('alt', 'Doubtful move')
+        img.attr('src', '../img/ui/doubtfulmove.svg')
+            .attr('alt', 'Doubtful move')
     else if (movestatus == 1)
-        img.set('src', '../img/ui/interestingmove.svg')
-            .set('alt', 'Interesting move')
+        img.attr('src', '../img/ui/interestingmove.svg')
+            .attr('alt', 'Interesting move')
     else if (movestatus == 2)
-        img.set('src', '../img/ui/goodmove.svg')
-            .set('alt', 'Good move')
+        img.attr('src', '../img/ui/goodmove.svg')
+            .attr('alt', 'Good move')
 
     if (movevalue == 2) img.alt = 'Very ' + img.alt.toLowerCase()
     img.title = img.alt
@@ -299,17 +299,17 @@ function setAnnotations(posstatus, posvalue, movestatus, movevalue) {
     else header.addClass('positionstatus')
 
     if (posstatus == -1)
-        img.set('src', '../img/ui/white.svg')
-            .set('alt', 'Good for white')
+        img.attr('src', '../img/ui/white.svg')
+            .attr('alt', 'Good for white')
     else if (posstatus == 0)
-        img.set('src', '../img/ui/balance.svg')
-            .set('alt', 'Even position')
+        img.attr('src', '../img/ui/balance.svg')
+            .attr('alt', 'Even position')
     else if (posstatus == 1)
-        img.set('src', '../img/ui/black.svg')
-            .set('alt', 'Good for black')
+        img.attr('src', '../img/ui/black.svg')
+            .attr('alt', 'Good for black')
     else if (posstatus == -2)
-        img.set('src', '../img/ui/unclear.svg')
-            .set('alt', 'Unclear position')
+        img.attr('src', '../img/ui/unclear.svg')
+            .attr('alt', 'Unclear position')
 
     if (posvalue == 2) img.alt = 'Very ' + img.alt.toLowerCase()
     img.title = img.alt
@@ -324,7 +324,7 @@ function getSliderValue() {
 }
 
 function setSliderValue(value, label) {
-    $('#sidebar .slider .inner span').css('top', value + '%').set('text', label)
+    $('#sidebar .slider .inner span').css('top', value + '%').attr('text', label)
 }
 
 function getFindMode() {
@@ -1402,7 +1402,7 @@ function showGameInfo() {
         || ['AB', 'AW', 'W', 'B'].some(function(x) { return x in rootNode })
 
     handicap.disabled = disabled
-    info.getElements('input[name^="size-"]').set('disabled', disabled)
+    info.getElements('input[name^="size-"]').attr('disabled', disabled)
     info.toggleClass('disabled', disabled)
 }
 
@@ -1420,11 +1420,11 @@ function showScore() {
         var tr = $('#score tbody tr' + (sign < 0 ? ':last-child' : ''))[0]
         var tds = tr.getElements('td')
 
-        tds[0].set('text', score['area_' + sign])
-        tds[1].set('text', score['territory_' + sign])
-        tds[2].set('text', score['captures_' + sign])
-        if (sign < 0) tds[3].set('text', getKomi())
-        tds[4].set('text', 0)
+        tds[0].attr('text', score['area_' + sign])
+        tds[1].attr('text', score['territory_' + sign])
+        tds[2].attr('text', score['captures_' + sign])
+        if (sign < 0) tds[3].attr('text', getKomi())
+        tds[4].attr('text', 0)
 
         setScoringMethod(setting.get('scoring.method'))
     }
@@ -1490,13 +1490,13 @@ function showGameChooser(restoreScrollbarPos) {
         ))
 
         var gamename = li.getElement('span')
-        var black = li.getElement('.black').set('text', gametree.getPlayerName(1, tree, 'Black'))
-        var white = li.getElement('.white').set('text', gametree.getPlayerName(-1, tree, 'White'))
+        var black = li.getElement('.black').attr('text', gametree.getPlayerName(1, tree, 'Black'))
+        var white = li.getElement('.white').attr('text', gametree.getPlayerName(-1, tree, 'White'))
 
-        if ('BR' in node) black.set('title', node.BR[0])
-        if ('WR' in node) white.set('title', node.WR[0])
-        if ('GN' in node) gamename.set('text', node.GN[0]).set('title', node.GN[0])
-        else if ('EV' in node) gamename.set('text', node.EV[0]).set('title', node.EV[0])
+        if ('BR' in node) black.attr('title', node.BR[0])
+        if ('WR' in node) white.attr('title', node.WR[0])
+        if ('GN' in node) gamename.attr('text', node.GN[0]).attr('title', node.GN[0])
+        else if ('EV' in node) gamename.attr('text', node.EV[0]).attr('title', node.EV[0])
 
         li.data('gametree', tree).getElement('div').on('click', function() {
             var link = this

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -13,12 +13,12 @@ function setIsBusy(busy) {
     clearTimeout(busyTimeout)
 
     if (busy) {
-        document.body.addClass('busy')
+        $('body').addClass('busy')
         return
     }
 
     busyTimeout = setTimeout(function() {
-        document.body.removeClass('busy')
+        $('body').removeClass('busy')
     }, setting.get('app.hide_busy_delay'))
 }
 
@@ -73,7 +73,7 @@ function setShowCoordinates(show) {
 }
 
 function getShowLeftSidebar() {
-    return document.body.hasClass('leftsidebar')
+    return $('body').hasClass('leftsidebar')
 }
 
 function setShowLeftSidebar(show) {
@@ -88,7 +88,7 @@ function setShowLeftSidebar(show) {
             win.setContentSize(size[0] + (show ? 1 : -1) * setting.get('view.leftsidebar_width'), size[1])
     }
 
-    document.body.toggleClass('leftsidebar', show)
+    $('body').toggleClass('leftsidebar', show)
 
     $('#leftsidebar').css('width', setting.get('view.leftsidebar_width'))
     $('#main').css('left', show ? setting.get('view.leftsidebar_width') : 0)
@@ -114,7 +114,7 @@ function getLeftSidebarWidth() {
 }
 
 function getShowSidebar() {
-    return document.body.hasClass('sidebar')
+    return $('body').hasClass('sidebar')
 }
 
 function setShowSidebar(show) {
@@ -129,7 +129,7 @@ function setShowSidebar(show) {
             win.setContentSize(size[0] + (show ? 1 : -1) * setting.get('view.sidebar_width'), size[1])
     }
 
-    document.body.toggleClass('sidebar', show)
+    $('body').toggleClass('sidebar', show)
 
     $('#sidebar').css('width', setting.get('view.sidebar_width'))
     $('#main').css('right', show ? setting.get('view.sidebar_width') : 0)
@@ -212,11 +212,11 @@ function setPlayerName(sign, name, tooltip) {
 }
 
 function getShowHotspot() {
-    return document.body.hasClass('bookmark')
+    return $('body').hasClass('bookmark')
 }
 
 function setShowHotspot(bookmark) {
-    document.body.toggleClass('bookmark', bookmark)
+    $('body').toggleClass('bookmark', bookmark)
 }
 
 function getCaptures() {
@@ -328,20 +328,20 @@ function setSliderValue(value, label) {
 }
 
 function getFindMode() {
-    return document.body.hasClass('find')
+    return $('body').hasClass('find')
 }
 
 function setFindMode(pickMode) {
     if (pickMode) {
         if (pickMode != getFindMode()) closeDrawers()
-        document.body.addClass('find')
+        $('body').addClass('find')
 
         var input = $('#find').getElement('input')
         input.focus()
         input.select()
     } else {
         hideIndicator()
-        document.body.removeClass('find')
+        $('body').removeClass('find')
         document.activeElement.blur()
     }
 }
@@ -355,37 +355,37 @@ function setFindText(text) {
 }
 
 function getEditMode() {
-    return document.body.hasClass('edit')
+    return $('body').hasClass('edit')
 }
 
 function setEditMode(editMode) {
     if (editMode) {
         closeDrawers()
-        document.body.addClass('edit')
+        $('body').addClass('edit')
 
         $('#properties textarea')[0].scrollTo(0, 0)
     } else {
         $('#goban').data('edittool-data', null)
-        document.body.removeClass('edit')
+        $('body').removeClass('edit')
     }
 }
 
 function getGuessMode() {
-    return document.body.hasClass('guess')
+    return $('body').hasClass('guess')
 }
 
 function setGuessMode(guessMode) {
     if (guessMode) {
         closeDrawers()
-        document.body.addClass('guess')
+        $('body').addClass('guess')
     } else {
-        document.body.removeClass('guess')
+        $('body').removeClass('guess')
         setCurrentTreePosition.apply(null, getCurrentTreePosition())
     }
 }
 
 function getScoringMode() {
-    return document.body.hasClass('scoring')
+    return $('body').hasClass('scoring')
 }
 
 function setScoringMode(mode, estimator) {
@@ -400,7 +400,7 @@ function setScoringMode(mode, estimator) {
         .removeClass('dead')
 
         closeDrawers()
-        document.body.addClass(type)
+        $('body').addClass(type)
 
         var deadstones = estimator ? getBoard().guessDeadStones() : getBoard().determineDeadStones()
         deadstones.forEach(function(v) {
@@ -409,12 +409,12 @@ function setScoringMode(mode, estimator) {
 
         updateAreaMap(estimator)
     } else {
-        document.body.removeClass(type)
+        $('body').removeClass(type)
     }
 }
 
 function getEstimatorMode() {
-    return document.body.hasClass('estimator')
+    return $('body').hasClass('estimator')
 }
 
 function setEstimatorMode(mode) {
@@ -594,7 +594,7 @@ function prepareScrollbars() {
         createElements: false
     }).create())
 
-    window.on('resize', function() {
+    $(window).on('resize', function() {
         if (!$('#gamechooser').hasClass('show')) return
 
         var width = $('#gamechooser .games-list')[0].getWidth() - 20
@@ -622,7 +622,7 @@ function prepareResizers() {
         $('#properties').css('transition', 'none')
     })
 
-    document.body.on('mouseup', function() {
+    $('body').on('mouseup', function() {
         var sidebarInitPosX = $('#sidebar').data('initposx')
         var leftSidebarInitPosX = $('#leftsidebar').data('initposx')
         var initPosY = $('#sidebar').data('initposy')
@@ -1576,10 +1576,10 @@ function closeDrawers() {
  * Main
  */
 
-document.on('domready', function() {
+$(document).ready(function() {
     document.title = app.getName()
 
-    document.body.on('mouseup', function() {
+    $('body').on('mouseup', function() {
         $('#goban').data('mousedown', false)
     })
 

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -873,8 +873,8 @@ function buildBoard() {
 
             var getEndTargetVertex = function(e) {
                 var endTarget = document.elementFromPoint(
-                    e.touches[0].pageX,
-                    e.touches[0].pageY
+                    e.originalEvent.touches[0].pageX,
+                    e.originalEvent.touches[0].pageY
                 )
 
                 if (!endTarget) return null
@@ -885,7 +885,10 @@ function buildBoard() {
                 return v
             }
 
-            $ol.append($li.append($('<div class="stone"/>').append($img).append($('<span/>')))
+            $ol.append(
+                $li.append(
+                    $('<div class="stone"/>').append($img).append($('<span/>'))
+                )
                 .on('mouseup', function(e) {
                     if (!$('#goban').data('mousedown')) return
 
@@ -893,10 +896,11 @@ function buildBoard() {
                     vertexClicked(this, e)
                 }.bind(vertex))
                 .on('touchend', function(e) {
-                    if (getEditMode() && ['line', 'arrow'].indexOf(getSelectedTool()) >= 0) {
-                        e.preventDefault()
-                        vertexClicked(null, { button: 0 })
-                    }
+                    if (!getEditMode() || ['line', 'arrow'].indexOf(getSelectedTool()) < 0)
+                        return
+
+                    e.preventDefault()
+                    vertexClicked(null, { button: 0 })
                 })
                 .on('mousemove', function(e) {
                     if (!$('#goban').data('mousedown')) return

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -253,7 +253,7 @@ function setCommentText(text) {
     var $textarea = $('#properties textarea')
 
     if ($textarea.val() != text) $textarea.val(text)
-    $container.attr('html', html)
+    $container.html(html)
     wireLinks($container)
 }
 

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -1551,7 +1551,7 @@ function showGameChooser(restoreScrollbarPos) {
     })
 
     $('#gamechooser').addClass('show')
-    window.fireEvent('resize')
+    $(window).trigger('resize')
     $('#gamechooser .gm-scroll-view')[0].scrollTo(0, scrollbarPos)
 }
 

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -319,7 +319,7 @@ function setAnnotations(posstatus, posvalue, movestatus, movevalue) {
 
 function getSliderValue() {
     var $span = $('#sidebar .slider .inner span').eq(0)
-    var value = parseFloat($span.css('top'))
+    var value = parseFloat($span.get(0).style.top)
     var label = $span.text()
 
     return [value, label]

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -242,7 +242,7 @@ function setCurrentPlayer(sign) {
 }
 
 function getCommentText() {
-    return $('#properties textarea').get('value')[0]
+    return $('#properties textarea').val()[0]
 }
 
 function setCommentText(text) {
@@ -250,20 +250,20 @@ function setCommentText(text) {
     var container = $('#properties .inner .comment')[0]
     var textarea = $('#properties textarea')[0]
 
-    if (textarea.get('value') != text) textarea.set('value', text)
+    if (textarea.val() != text) textarea.val(text)
     container.set('html', html)
     wireLinks(container)
 }
 
 function getCommentTitle() {
-    return $('#properties .edit .header input')[0].get('value')
+    return $('#properties .edit .header input').eq(0).val()
 }
 
 function setCommentTitle(text) {
     var input = $('#properties .edit .header input')[0]
 
     $('#properties .inner .header span')[0].set('text', text.trim() != '' ? text : getCurrentMoveInterpretation())
-    if (input.get('value') != text) input.set('value', text)
+    if (input.val() != text) input.val(text)
 }
 
 function setAnnotations(posstatus, posvalue, movestatus, movevalue) {
@@ -738,7 +738,7 @@ function addEngineItem(name, path, args) {
                     if (result) {
                         this.getParent('li')
                             .getElement('h3 + p input')
-                            .set('value', result[0])
+                            .val(result[0])
                             .focus()
                     }
 
@@ -1027,7 +1027,7 @@ function hideIndicator() {
 
 function clearConsole() {
     $('#console .inner pre, #console .inner form:not(:last-child)').dispose()
-    $('#console .inner form:last-child input')[0].set('value', '').focus()
+    $('#console .inner form:last-child input').eq(0).val('').focus()
     $('#console').data('scrollbar').update()
 }
 
@@ -1383,14 +1383,14 @@ function showGameInfo() {
 
     for (var key in data) {
         var value = data[key]
-        info.getElement('input[name="' + key + '"]').set('value', value in rootNode ? rootNode[value][0] : '')
+        info.getElement('input[name="' + key + '"]').val(value in rootNode ? rootNode[value][0] : '')
     }
 
-    info.getElement('input[name="name_1"]').set('value', gametree.getPlayerName(1, tree, ''))
-    info.getElement('input[name="name_-1"]').set('value', gametree.getPlayerName(-1, tree, ''))
-    info.getElement('input[name="komi"]').set('value', 'KM' in rootNode ? +rootNode.KM[0] : '')
-    info.getElement('input[name="size-width"]').set('value', getBoard().width)
-    info.getElement('input[name="size-height"]').set('value', getBoard().height)
+    info.getElement('input[name="name_1"]').val(gametree.getPlayerName(1, tree, ''))
+    info.getElement('input[name="name_-1"]').val(gametree.getPlayerName(-1, tree, ''))
+    info.getElement('input[name="komi"]').val('KM' in rootNode ? +rootNode.KM[0] : '')
+    info.getElement('input[name="size-width"]').val(getBoard().width)
+    info.getElement('input[name="size-height"]').val(getBoard().height)
     info.getElements('section .menu').removeClass('active').data('engineindex', -1)
 
     var handicap = info.getElement('select[name="handicap"]')
@@ -1465,7 +1465,7 @@ function showGameChooser(restoreScrollbarPos) {
 
     closeDrawers()
 
-    $('#gamechooser > input')[0].set('value', '').focus()
+    $('#gamechooser > input').eq(0).val('').focus()
     $('#gamechooser ol')[0].empty()
 
     var trees = getGameTrees()
@@ -1521,16 +1521,16 @@ function showGameChooser(restoreScrollbarPos) {
 
         if (x <= middle - 10 && !this.hasClass('insertleft')) {
             $('#gamechooser ol li').removeClass('insertleft').removeClass('insertright')
-            this.addClass('insertleft')
+            $(this).addClass('insertleft')
         } else if (x > middle + 10 && !this.hasClass('insertright')) {
             $('#gamechooser ol li').removeClass('insertleft').removeClass('insertright')
-            this.addClass('insertright')
+            $(this).addClass('insertright')
         }
     })
 
     $('#gamechooser').off('drop').on('drop', function(e) {
-        var dragged = this.data('dragging')
-        this.data('dragging', null)
+        var dragged = $(this).data('dragging')
+        $(this).data('dragging', null)
 
         var lis = $('#gamechooser ol li')
         var afterli = lis.filter(function(x) { return x.hasClass('insertleft') })[0]

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -188,7 +188,7 @@ function getSidebarWidth() {
 function setSidebarWidth(width) {
     if (!getShowSidebar()) return
     $('#sidebar').css('width', width)
-    $('#.sidebar #main').css('right', width)
+    $('.sidebar #main').css('right', width)
 }
 
 function getPropertiesHeight() {
@@ -234,11 +234,11 @@ function setCaptures(captures) {
 }
 
 function getCurrentPlayer() {
-    return $('#.currentplayer')[0].attr('src') == '../img/ui/blacktoplay.svg' ? 1 : -1
+    return $('.currentplayer').eq(0).attr('src') == '../img/ui/blacktoplay.svg' ? 1 : -1
 }
 
 function setCurrentPlayer(sign) {
-    $('#.currentplayer').attr('src', sign > 0 ? '../img/ui/blacktoplay.svg' : '../img/ui/whitetoplay.svg')
+    $('.currentplayer').attr('src', sign > 0 ? '../img/ui/blacktoplay.svg' : '../img/ui/whitetoplay.svg')
 }
 
 function getCommentText() {
@@ -611,7 +611,7 @@ function prepareScrollbars() {
 }
 
 function prepareResizers() {
-    $('#.verticalresizer').on('mousedown', function(e) {
+    $('.verticalresizer').on('mousedown', function(e) {
         if (e.event.button != 0) return
         this.getParent().data('initposx', [e.event.screenX, parseFloat(this.getParent().width())])
     })

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -203,7 +203,7 @@ function setPropertiesHeight(height) {
 
 function getPlayerName(sign) {
     var el = $('#player_' + sign + ' .name')[0]
-    return [el.get('text'), el.get('title')]
+    return [el.attr('text'), el.attr('title')]
 }
 
 function setPlayerName(sign, name, tooltip) {
@@ -221,8 +221,8 @@ function setShowHotspot(bookmark) {
 
 function getCaptures() {
     return {
-        '-1': +$('#player_-1 .captures')[0].get('text'),
-        '1': +$('#player_1 .captures')[0].get('text')
+        '-1': +$('#player_-1 .captures')[0].attr('text'),
+        '1': +$('#player_1 .captures')[0].attr('text')
     }
 }
 
@@ -234,7 +234,7 @@ function setCaptures(captures) {
 }
 
 function getCurrentPlayer() {
-    return $('#.currentplayer')[0].get('src') == '../img/ui/blacktoplay.svg' ? 1 : -1
+    return $('#.currentplayer')[0].attr('src') == '../img/ui/blacktoplay.svg' ? 1 : -1
 }
 
 function setCurrentPlayer(sign) {
@@ -318,7 +318,7 @@ function setAnnotations(posstatus, posvalue, movestatus, movevalue) {
 function getSliderValue() {
     var span = $('#sidebar .slider .inner span')[0]
     var value = parseFloat(span.css('top'))
-    var label = span.get('text')
+    var label = span.attr('text')
 
     return [value, label]
 }
@@ -687,7 +687,7 @@ function prepareGameChooser() {
 
         $('#gamechooser .games-list li:not(.add)').forEach(function(li) {
             if (li.getElements('span').some(function(span) {
-                return span.get('text').toLowerCase().indexOf(value.toLowerCase()) >= 0
+                return span.attr('text').toLowerCase().indexOf(value.toLowerCase()) >= 0
             })) li.removeClass('hide')
             else li.addClass('hide')
         })
@@ -799,7 +799,7 @@ function showMessageBox(message, type, buttons, cancelId) {
 
 function readjustShifts(vertex) {
     var li = $('#goban .pos_' + vertex.join('-'))[0]
-    var direction = li.get('class').split(' ').filter(function(x) {
+    var direction = li.attr('class').split(' ').filter(function(x) {
         return x.indexOf('shift_') == 0
     }).map(function(x) {
         return +x.replace('shift_', '')
@@ -1041,7 +1041,7 @@ function wireLinks(container) {
 
             shell.openExternal(this.href)
         } else if (this.hasClass('movenumber')) {
-            var movenumber = +this.get('text').slice(1)
+            var movenumber = +this.attr('text').slice(1)
             setUndoable(true, 'Go Back')
             goToMainVariation()
 
@@ -1053,7 +1053,7 @@ function wireLinks(container) {
     })
 
     container.getElements('.coord').on('mouseenter', function() {
-        var v = getBoard().coord2vertex(this.get('text'))
+        var v = getBoard().coord2vertex(this.attr('text'))
         showIndicator(v)
     }).on('mouseleave', function() {
         if (!getFindMode()) hideIndicator()

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -110,7 +110,7 @@ function setLeftSidebarWidth(width) {
 }
 
 function getLeftSidebarWidth() {
-    return parseFloat($('#leftsidebar').width())
+    return parseFloat($('#leftsidebar').css('width'))
 }
 
 function getShowSidebar() {
@@ -140,11 +140,11 @@ function setShowSidebar(show) {
         updateCommentText();
     } else {
         // Clear game graph
-        var s = $('#graph').data('sigma')
+        var sigma = $('#graph').data('sigma')
 
-        if (s) {
-            s.graph.clear()
-            s.refresh()
+        if (sigma) {
+            sigma.graph.clear()
+            sigma.refresh()
         }
     }
 
@@ -182,7 +182,7 @@ function getShowComment() {
 }
 
 function getSidebarWidth() {
-    return parseFloat($('#sidebar').width())
+    return parseFloat($('#sidebar').css('width'))
 }
 
 function setSidebarWidth(width) {
@@ -203,7 +203,7 @@ function setPropertiesHeight(height) {
 
 function getPlayerName(sign) {
     var $el = $('#player_' + sign + ' .name')
-    return [$el.attr('text'), $el.attr('title')]
+    return [$el.text(), $el.attr('title')]
 }
 
 function setPlayerName(sign, name, tooltip) {
@@ -221,8 +221,8 @@ function setShowHotspot(bookmark) {
 
 function getCaptures() {
     return {
-        '-1': +$('#player_-1 .captures').attr('text'),
-        '1': +$('#player_1 .captures').attr('text')
+        '-1': +$('#player_-1 .captures').text(),
+        '1': +$('#player_1 .captures').text()
     }
 }
 
@@ -320,7 +320,7 @@ function setAnnotations(posstatus, posvalue, movestatus, movevalue) {
 function getSliderValue() {
     var $span = $('#sidebar .slider .inner span').eq(0)
     var value = parseFloat($span.css('top'))
-    var label = $span.attr('text')
+    var label = $span.text()
 
     return [value, label]
 }
@@ -689,7 +689,7 @@ function prepareGameChooser() {
 
         $('#gamechooser .games-list li:not(.add)').get().forEach(function(li) {
             if ($(li).children('span').some(function(span) {
-                return span.attr('text').toLowerCase().indexOf(value.toLowerCase()) >= 0
+                return span.text().toLowerCase().indexOf(value.toLowerCase()) >= 0
             })) $(li).removeClass('hide')
             else $(li).addClass('hide')
         })
@@ -1047,7 +1047,7 @@ function wireLinks($container) {
 
             shell.openExternal(this.href)
         } else if ($(this).hasClass('movenumber')) {
-            var movenumber = +$(this).attr('text').slice(1)
+            var movenumber = +$(this).text().slice(1)
             setUndoable(true, 'Go Back')
             goToMainVariation()
 
@@ -1059,7 +1059,7 @@ function wireLinks($container) {
     })
 
     $container.children('.coord').on('mouseenter', function() {
-        var v = getBoard().coord2vertex($(this).attr('text'))
+        var v = getBoard().coord2vertex($(this).text())
         showIndicator(v)
     }).on('mouseleave', function() {
         if (!getFindMode()) hideIndicator()

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -599,16 +599,16 @@ function prepareScrollbars() {
     $(window).on('resize', function() {
         if (!$('#gamechooser').hasClass('show')) return
 
-        var width = $('#gamechooser .games-list')[0].getWidth() - 20
-        var svgs = $('#gamechooser svg')
+        var width = $('#gamechooser .games-list').width() - 20
+        var $svgs = $('#gamechooser svg')
 
-        if (svgs.length == 0) return
+        if ($svgs.length == 0) return
 
-        var liwidth = svgs[0].getWidth() + 12 + 20
+        var liwidth = $svgs.eq(0).width() + 12 + 20
         var count = Math.floor(width / liwidth)
 
         $('#gamechooser li').css('width', Math.floor(width / count) - 20)
-        $('#gamechooser .games-list')[0].data('scrollbar').update()
+        $('#gamechooser .games-list').data('scrollbar').update()
     })
 }
 
@@ -943,13 +943,16 @@ function buildBoard() {
 }
 
 function updateBoardLines() {
+    var tx = parseFloat($('#goban').css('border-left-width'))
+    var ty = parseFloat($('#goban').css('border-top-width'))
+
     $('#goban hr').get().forEach(function(line) {
         var v1 = $(line).data('v1'), v2 = $(line).data('v2')
         var mirrored = v2[0] < v1[0]
         var $li1 = $('#goban').find('.pos_' + v1[0] + '-' + v1[1])
         var $li2 = $('#goban').find('.pos_' + v2[0] + '-' + v2[1])
-        var pos1 = $li1.position($('#goban'))
-        var pos2 = $li2.position($('#goban'))
+        var pos1 = $li1.position()
+        var pos2 = $li2.position()
         var dy = pos2.top - pos1.top, dx = pos2.left - pos1.left
 
         var angle = Math.atan(dy / dx) * 180 / Math.PI
@@ -957,8 +960,8 @@ function updateBoardLines() {
         var length = Math.sqrt(dx * dx + dy * dy)
 
         $(line).css({
-            top: (pos1.top + $li1.innerHeight() / 2 + pos2.top + $li2.innerHeight() / 2) / 2 - 2,
-            left: (pos1.left + $li1.innerWidth() / 2 + pos2.left + $li2.innerWidth() / 2) / 2 - 2,
+            top: (pos1.top + $li1.height() / 2 + pos2.top + $li2.height() / 2) / 2 + ty,
+            left: (pos1.left + $li1.width() / 2 + pos2.left + $li2.width() / 2) / 2 + tx,
             marginLeft: -length / 2,
             width: length,
             transform: 'rotate(' + angle + 'deg)'
@@ -970,8 +973,8 @@ function resizeBoard() {
     var board = getBoard()
     if (!board) return
 
-    var outerWidth = $('main').width()
-    var outerHeight = $('main').height()
+    var outerWidth = helper.floorEven($('main').width())
+    var outerHeight = helper.floorEven($('main').height())
     var boardWidth = board.width
     var boardHeight = board.height
     var width = helper.floorEven(outerWidth - $('#goban').outerWidth() + $('#goban').width())
@@ -1469,7 +1472,7 @@ function showGameChooser(restoreScrollbarPos) {
     closeDrawers()
 
     $('#gamechooser > input').eq(0).val('').focus()
-    $('#gamechooser ol')[0].empty()
+    $('#gamechooser ol').eq(0).empty()
 
     var trees = getGameTrees()
     var currentTree = getRootTree()
@@ -1493,7 +1496,7 @@ function showGameChooser(restoreScrollbarPos) {
             .append($('<span class="white"/>').text('White'))
         ))
 
-        var $gamename = $li.find('span')
+        var $gamename = $li.find('span').eq(0)
         var $black = $li.find('.black').text(gametree.getPlayerName(1, tree, 'Black'))
         var $white = $li.find('.white').text(gametree.getPlayerName(-1, tree, 'White'))
 

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -227,9 +227,11 @@ function getCaptures() {
 }
 
 function setCaptures(captures) {
-    $('#player_-1 .captures')[0].text(captures['-1'])
+    $('#player_-1 .captures')
+        .text(captures['-1'])
         .css('opacity', captures['-1'] == 0 ? 0 : .7)
-    $('#player_1 .captures')[0].text(captures['1'])
+    $('#player_1 .captures')
+        .text(captures['1'])
         .css('opacity', captures['1'] == 0 ? 0 : .7)
 }
 
@@ -573,24 +575,24 @@ function getCurrentMoveInterpretation() {
 
 function prepareScrollbars() {
     $('#properties').data('scrollbar', new GeminiScrollbar({
-        element: $('#properties'),
+        element: $('#properties').get(0),
         createElements: false
     }).create())
 
     $('#console').data('scrollbar', new GeminiScrollbar({
-        element: $('#console'),
+        element: $('#console').get(0),
         createElements: false
     }).create())
 
-    var enginesList = $('#preferences .engines-list')[0]
-    enginesList.data('scrollbar', new GeminiScrollbar({
-        element: enginesList,
+    var $enginesList = $('#preferences .engines-list')
+    $enginesList.data('scrollbar', new GeminiScrollbar({
+        element: $enginesList.get(0),
         createElements: false
     }).create())
 
-    var gamesList = $('#gamechooser .games-list')[0]
-    gamesList.data('scrollbar', new GeminiScrollbar({
-        element: gamesList,
+    var $gamesList = $('#gamechooser .games-list')
+    $gamesList.data('scrollbar', new GeminiScrollbar({
+        element: $gamesList.get(0),
         createElements: false
     }).create())
 
@@ -772,7 +774,7 @@ function addEngineItem(name, path, args) {
     )
 
     $ul.append($li)
-    $li.find('h3 input').focus()
+    $li.find('h3 input').get(0).focus()
 
     var enginesScrollbar = $('#preferences .engines-list').data('scrollbar')
     if (enginesScrollbar) enginesScrollbar.update()
@@ -799,8 +801,8 @@ function showMessageBox(message, type, buttons, cancelId) {
 }
 
 function readjustShifts(vertex) {
-    var li = $('#goban .pos_' + vertex.join('-'))[0]
-    var direction = li.attr('class').split(' ').filter(function(x) {
+    var $li = $('#goban .pos_' + vertex.join('-'))
+    var direction = $li.attr('class').split(' ').filter(function(x) {
         return x.indexOf('shift_') == 0
     }).map(function(x) {
         return +x.replace('shift_', '')
@@ -813,24 +815,24 @@ function readjustShifts(vertex) {
 
     if (direction == 1 || direction == 5 || direction == 8) {
         // Left
-        query = '#goban .pos_' + (vertex[0] - 1) + '-' + vertex[1]
+        query = (vertex[0] - 1) + '-' + vertex[1]
         removeShifts = [3, 7, 6]
     } else if (direction == 2 || direction == 5 || direction == 6) {
         // Top
-        query = '#goban .pos_' + vertex[0] + '-' + (vertex[1] - 1)
+        query = vertex[0] + '-' + (vertex[1] - 1)
         removeShifts = [4, 7, 8]
     } else if (direction == 3 || direction == 7 || direction == 6) {
         // Right
-        query = '#goban .pos_' + (vertex[0] + 1) + '-' + vertex[1]
+        query = (vertex[0] + 1) + '-' + vertex[1]
         removeShifts = [1, 5, 8]
     } else if (direction == 4 || direction == 7 || direction == 8) {
         // Bottom
-        query = '#goban .pos_' + vertex[0] + '-' + (vertex[1] + 1)
+        query = vertex[0] + '-' + (vertex[1] + 1)
         removeShifts = [2, 5, 6]
     }
 
     if (query && removeShifts) {
-        var $el = $(query)
+        var $el = $('#goban .pos_' + query)
         $el.addClass('animate')
         removeShifts.forEach(function(s) { $el.removeClass('shift_' + s) })
         setTimeout(function() { $el.removeClass('animate') }, 200)
@@ -941,22 +943,22 @@ function buildBoard() {
 }
 
 function updateBoardLines() {
-    $('#goban hr').forEach(function(line) {
-        var v1 = line.data('v1'), v2 = line.data('v2')
+    $('#goban hr').get().forEach(function(line) {
+        var v1 = $(line).data('v1'), v2 = $(line).data('v2')
         var mirrored = v2[0] < v1[0]
-        var li1 = $('#goban').find('.pos_' + v1[0] + '-' + v1[1])
-        var li2 = $('#goban').find('.pos_' + v2[0] + '-' + v2[1])
-        var pos1 = li1.getPosition($('#goban'))
-        var pos2 = li2.getPosition($('#goban'))
-        var dy = pos2.y - pos1.y, dx = pos2.x - pos1.x
+        var $li1 = $('#goban').find('.pos_' + v1[0] + '-' + v1[1])
+        var $li2 = $('#goban').find('.pos_' + v2[0] + '-' + v2[1])
+        var pos1 = $li1.position($('#goban'))
+        var pos2 = $li2.position($('#goban'))
+        var dy = pos2.top - pos1.top, dx = pos2.left - pos1.left
 
         var angle = Math.atan(dy / dx) * 180 / Math.PI
         if (mirrored) angle += 180
         var length = Math.sqrt(dx * dx + dy * dy)
 
-        line.setStyles({
-            top: (pos1.y + li1.innerHeight() / 2 + pos2.y + li2.innerHeight() / 2) / 2 - 2,
-            left: (pos1.x + li1.innerWidth() / 2 + pos2.x + li2.innerWidth() / 2) / 2 - 2,
+        $(line).css({
+            top: (pos1.top + $li1.innerHeight() / 2 + pos2.top + $li2.innerHeight() / 2) / 2 - 2,
+            left: (pos1.left + $li1.innerWidth() / 2 + pos2.left + $li2.innerWidth() / 2) / 2 - 2,
             marginLeft: -length / 2,
             width: length,
             transform: 'rotate(' + angle + 'deg)'
@@ -1008,22 +1010,22 @@ function resizeBoard() {
 
 function showIndicator(vertex) {
     var x = vertex[0], y = vertex[1]
-    var li = $('#goban .pos_' + x + '-' + y)
+    var $li = $('#goban .pos_' + x + '-' + y)
 
-    if (li.length == 0) return
-    li = li[0]
+    if ($li.length == 0) return
 
-    $('#indicator').css('top', li.position().top)
-        .css('left', li.position().left)
-        .css('height', li.innerHeight())
-        .css('width', li.innerWidth())
-        .data('vertex', vertex)
+    $('#indicator').css('top', $li.position().top)
+    .css('left', $li.position().left)
+    .css('height', $li.innerHeight())
+    .css('width', $li.innerWidth())
+    .data('vertex', vertex)
 }
 
 function hideIndicator() {
-    $('#indicator').css('top', '')
-        .css('left', '')
-        .data('vertex', null)
+    $('#indicator')
+    .css('top', ' ')
+    .css('left', ' ')
+    .data('vertex', null)
 }
 
 function clearConsole() {

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -873,8 +873,8 @@ function buildBoard() {
 
             var getEndTargetVertex = function(e) {
                 var endTarget = document.elementFromPoint(
-                    e.originalEvent.touches[0].pageX,
-                    e.originalEvent.touches[0].pageY
+                    e.touches[0].pageX,
+                    e.touches[0].pageY
                 )
 
                 if (!endTarget) return null

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -978,8 +978,12 @@ function resizeBoard() {
     var board = getBoard()
     if (!board) return
 
-    var outerWidth = parseFloat($('main').css('width'))
-    var outerHeight = parseFloat($('main').css('height'))
+    $('main').css('width', '').css('height', '')
+    var outerWidth = Math.round($('main').width())
+    var outerHeight = Math.round($('main').height())
+    if ((outerWidth - outerHeight) % 2 != 0)
+        $('main').css('width', outerWidth + 1)
+
     var boardWidth = board.width
     var boardHeight = board.height
     var width = helper.floorEven(outerWidth - $('#goban').outerWidth() + $('#goban').width())

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -1108,8 +1108,8 @@ function openHeaderMenu() {
     menu = Menu.buildFromTemplate(template)
     menu.popup(
         remote.getCurrentWindow(),
-        Math.round($('#headermenu').position().left),
-        Math.round($('#header')[0].getCoordinates().top)
+        Math.round($('#headermenu').offset().left),
+        Math.round($('header').offset().top)
     )
 }
 
@@ -1210,10 +1210,14 @@ function openCommentMenu() {
         }
     })
 
-    var coord = $('#properties .edit .header img')[0].getCoordinates()
-
     menu = Menu.buildFromTemplate(template)
-    menu.popup(remote.getCurrentWindow(), Math.round(coord.left), Math.round(coord.bottom))
+    var $el = $('#properties .edit .header img')
+    
+    menu.popup(
+        remote.getCurrentWindow(),
+        Math.round($el.offset().left),
+        Math.round($el.offset().top + $el.height())
+    )
 }
 
 function openEnginesMenu(element, callback) {

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -978,8 +978,8 @@ function resizeBoard() {
     var board = getBoard()
     if (!board) return
 
-    var outerWidth = helper.floorEven($('main').width())
-    var outerHeight = helper.floorEven($('main').height())
+    var outerWidth = parseFloat($('main').css('width'))
+    var outerHeight = parseFloat($('main').css('height'))
     var boardWidth = board.width
     var boardHeight = board.height
     var width = helper.floorEven(outerWidth - $('#goban').outerWidth() + $('#goban').width())

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -714,66 +714,64 @@ function addEngineItem(name, path, args) {
     if (!path) path = ''
     if (!args) args = ''
 
-    var ul = $('#preferences .engines-list ul')[0]
-    var li = new Element('li').append(new Element('h3').append(
-        new Element('input', {
-            type: 'text',
-            placeholder: '(Unnamed engine)',
-            value: name
-        })
+    var $ul = $('#preferences .engines-list ul').eq(0)
+    var $li = $('<li/>').append($('<h3/>').append(
+        $('<input/>')
+        .attr('type', 'text')
+        .attr('placeholder', '(Unnamed engine)')
+        .val(name)
     )).append(
-        new Element('p').append(new Element('input', {
-            type: 'text',
-            placeholder: 'Path',
-            value: path
-        })).append(new Element('a.browse', {
-            events: {
-                click: function() {
-                    setIsBusy(true)
+        $('<p/>').append(
+            $('<input/>')
+            .attr('type', 'text')
+            .attr('placeholder', 'Path')
+            .val(path)
+        )).append(
+            $('<a class="browse"/>')
+            .on('click', function() {
+                setIsBusy(true)
 
-                    var result = dialog.showOpenDialog(remote.getCurrentWindow(), {
-                        filters: [{ name: 'All Files', extensions: ['*'] }]
-                    })
+                var result = dialog.showOpenDialog(remote.getCurrentWindow(), {
+                    filters: [{ name: 'All Files', extensions: ['*'] }]
+                })
 
-                    if (result) {
-                        this.getParent('li')
-                            .find('h3 + p input')
-                            .val(result[0])
-                            .focus()
-                    }
-
-                    setIsBusy(false)
+                if (result) {
+                    this.parents('li').eq(0)
+                        .find('h3 + p input')
+                        .val(result[0])
+                        .focus()
                 }
-            }
-        }).append(new Element('img', {
-            src: '../node_modules/octicons/svg/file-directory.svg',
-            title: 'Browse…',
-            height: 14
-        })))
+
+                setIsBusy(false)
+            })
+        }).append(
+            $('<img/>')
+            .attr('src', '../node_modules/octicons/svg/file-directory.svg')
+            .attr('title', 'Browse…')
+            .attr('height', 14)
+        )))
     ).append(
-        new Element('p').append(new Element('input', {
-            type: 'text',
-            placeholder: 'No arguments',
-            value: args
-        }))
+        $('<p/>').append(
+            $('<input/>')
+            .attr('type', 'text')
+            .attr('placeholder', 'No arguments')
+            .attr('value', args)
+        ))
     ).append(
-        new Element('a.remove', {
-            events: {
-                click: function() {
-                    this.getParent('li').dispose()
-                    $('#preferences .engines-list')[0].data('scrollbar').update()
-                }
-            }
-        }).append(new Element('img', {
-            src: '../node_modules/octicons/svg/x.svg',
-            height: 14
-        }))
+        $('<a class="remove"/>').on('click', function() {
+            this.parents('li').eq(0).remove()
+            $('#preferences .engines-list')[0].data('scrollbar').update()
+        }).append(
+            $('img')
+            .attr('src', '../node_modules/octicons/svg/x.svg')
+            .attr('height', 14)
+        ))
     )
 
-    ul.append(li)
-    li.find('h3 input').focus()
+    $ul.append($li)
+    $li.find('h3 input').focus()
 
-    var enginesScrollbar = $('#preferences .engines-list')[0].data('scrollbar')
+    var enginesScrollbar = $('#preferences .engines-list').data('scrollbar')
     if (enginesScrollbar) enginesScrollbar.update()
 }
 
@@ -853,19 +851,19 @@ function buildBoard() {
     var hoshi = board.getHandicapPlacement(9)
 
     for (var y = 0; y < board.height; y++) {
-        var ol = new Element('ol.row')
+        var $ol = $('<ol class="row"/>')
 
         for (var x = 0; x < board.width; x++) {
             var vertex = [x, y]
-            var img = new Element('img', { src: '../img/goban/stone_0.svg' })
-            var li = new Element('li')
-                .data('vertex', vertex)
-                .addClass('pos_' + x + '-' + y)
-                .addClass('shift_' + Math.floor(Math.random() * 9))
-                .addClass('random_' + Math.floor(Math.random() * 5))
+            var $img = $('<img/>').attr('src', '../img/goban/stone_0.svg')
+            var $li = $('<li/>')
+            .data('vertex', vertex)
+            .addClass('pos_' + x + '-' + y)
+            .addClass('shift_' + Math.floor(Math.random() * 9))
+            .addClass('random_' + Math.floor(Math.random() * 5))
 
             if (hoshi.some(function(v) { return helper.equals(v, vertex) }))
-                li.addClass('hoshi')
+                $li.addClass('hoshi')
 
             var getEndTargetVertex = function(e) {
                 var endTarget = document.elementFromPoint(
@@ -874,14 +872,14 @@ function buildBoard() {
                 )
 
                 if (!endTarget) return null
-                var v = endTarget.data('vertex')
-                if (!v) endTarget = endTarget.getParent('li')
-                if (endTarget) v = endTarget.data('vertex')
+                var v = $(endTarget).data('vertex')
+                if (!v) endTarget = $(endTarget).parents('li').get(0)
+                if (endTarget) v = $(endTarget).data('vertex')
 
                 return v
             }
 
-            ol.adopt(li.adopt(new Element('div.stone').adopt(img).adopt(new Element('span')))
+            $ol.append($li.append($('<div class="stone"/>').append($img).append($('<span/>')))
                 .on('mouseup', function(e) {
                     if (!$('#goban').data('mousedown')) return
 
@@ -907,35 +905,35 @@ function buildBoard() {
                 .on('mousedown', function() {
                     $('#goban').data('mousedown', true)
                 })
-                .append(new Element('div.paint'))
+                .append($('<div class="paint"/>'))
             )
         }
 
-        rows.push(ol)
+        rows.push($ol)
     }
 
     var alpha = 'ABCDEFGHJKLMNOPQRSTUVWXYZ'
-    var coordx = new Element('ol.coordx')
-    var coordy = new Element('ol.coordy')
+    var $coordx = $('<ol class="coordx"/>')
+    var $coordy = $('<ol class="coordy"/>')
 
     for (var i = 0; i < board.width; i++) {
-        coordx.adopt(new Element('li', { text: alpha[i] }))
+        $coordx.append($('<li/>').text(alpha[i]))
     }
 
     for (var i = board.height; i > 0; i--) {
-        coordy.adopt(new Element('li', { text: i }))
+        $coordy.append($('<li/>').text(i))
     }
 
-    var goban = $('#goban div')[0]
-    goban.empty().adopt(rows, coordx, coordy)
-    goban.append(coordx.clone(), 'top').append(coordy.clone(), 'top')
+    var $goban = $('#goban div').eq(0)
+    $goban.empty().append(rows).append($coordx).append($coordy)
+    $goban.prepend($coordx.clone()).prepend($coordy.clone())
 
     resizeBoard()
 
     // Readjust shifts
 
-    $('#goban .row li:not(.shift_0)').forEach(function(li) {
-        readjustShifts(li.data('vertex'))
+    $('#goban .row li:not(.shift_0)').get().forEach(function(li) {
+        readjustShifts($(li).data('vertex'))
     })
 }
 
@@ -1026,7 +1024,7 @@ function hideIndicator() {
 }
 
 function clearConsole() {
-    $('#console .inner pre, #console .inner form:not(:last-child)').dispose()
+    $('#console .inner pre, #console .inner form:not(:last-child)').remove()
     $('#console .inner form:last-child input').eq(0).val('').focus()
     $('#console').data('scrollbar').update()
 }
@@ -1282,7 +1280,7 @@ function openGameMenu(element, event) {
                     ['Remove Game', 'Cancel'], 1
                 ) == 1) return
 
-                var index = element.getParent('ol').children('li div').indexOf(element)
+                var index = element.parents('ol').eq(0).children('li div').indexOf(element)
                 trees.splice(index, 1)
 
                 setGameTrees(trees)
@@ -1306,7 +1304,7 @@ function openGameMenu(element, event) {
                     ['Remove Games', 'Cancel'], 1
                 ) == 1) return
 
-                setGameTrees([element.getParent('li').data('gametree')])
+                setGameTrees([element.parents('li').eq(0).data('gametree')])
                 setGameIndex(0)
                 showGameChooser(true)
             }
@@ -1473,7 +1471,7 @@ function showGameChooser(restoreScrollbarPos) {
 
     for (var i = 0; i < trees.length; i++) {
         var tree = trees[i]
-        var li = new Element('li')
+        var $li = $('<li/>')
         var tp = gametree.navigate(tree, 0, 30)
         if (!tp) tp = gametree.navigate(tree, 0, gametree.getCurrentHeight(tree) - 1)
 
@@ -1481,34 +1479,35 @@ function showGameChooser(restoreScrollbarPos) {
         var svg = board.getSvg(setting.get('gamechooser.thumbnail_size'))
         var node = tree.nodes[0]
 
-        $('#gamechooser ol')[0].append(li.append(
-            new Element('div', { draggable: true })
-            .append(new Element('span'))
+        $('#gamechooser ol').eq(0).append($li.append(
+            $('<div/>')
+            .attr('draggable', 'true')
+            .append($('<span/>'))
             .append(svg)
-            .append(new Element('span.black', { text: 'Black' }))
-            .append(new Element('span.white', { text: 'White' }))
+            .append($('<span class="black"/>').text('Black'))
+            .append($('<span class="white"/>').text('White'))
         ))
 
-        var gamename = li.find('span')
-        var black = li.find('.black').attr('text', gametree.getPlayerName(1, tree, 'Black'))
-        var white = li.find('.white').attr('text', gametree.getPlayerName(-1, tree, 'White'))
+        var $gamename = $li.find('span')
+        var $black = $li.find('.black').attr('text', gametree.getPlayerName(1, tree, 'Black'))
+        var $white = $li.find('.white').attr('text', gametree.getPlayerName(-1, tree, 'White'))
 
-        if ('BR' in node) black.attr('title', node.BR[0])
-        if ('WR' in node) white.attr('title', node.WR[0])
-        if ('GN' in node) gamename.attr('text', node.GN[0]).attr('title', node.GN[0])
-        else if ('EV' in node) gamename.attr('text', node.EV[0]).attr('title', node.EV[0])
+        if ('BR' in node) $black.attr('title', node.BR[0])
+        if ('WR' in node) $white.attr('title', node.WR[0])
+        if ('GN' in node) $gamename.attr('text', node.GN[0]).attr('title', node.GN[0])
+        else if ('EV' in node) $gamename.attr('text', node.EV[0]).attr('title', node.EV[0])
 
-        li.data('gametree', tree).find('div').on('click', function() {
+        $li.data('gametree', tree).find('div').on('click', function() {
             var link = this
             closeGameChooser()
             setTimeout(function() {
-                setGameIndex($('#gamechooser ol li div').indexOf(link))
+                setGameIndex($('#gamechooser ol li div').get().indexOf(link))
             }, 500)
         }).on('mouseup', function(e) {
             if (e.event.button != 2) return
             openGameMenu(this, e.event)
         }).on('dragstart', function(e) {
-            $('#gamechooser').data('dragging', this.getParent('li'))
+            $('#gamechooser').data('dragging', $(this).parents('li').eq(0))
         })
     }
 
@@ -1517,7 +1516,7 @@ function showGameChooser(restoreScrollbarPos) {
         if (!$('#gamechooser').data('dragging')) return
 
         var x = e.event.clientX
-        var middle = this.position().left + this.innerWidth() / 2
+        var middle = $(this).position().left + $(this).innerWidth() / 2
 
         if (x <= middle - 10 && !$(this).hasClass('insertleft')) {
             $('#gamechooser ol li').removeClass('insertleft').removeClass('insertright')
@@ -1542,8 +1541,8 @@ function showGameChooser(restoreScrollbarPos) {
         if (afterli) $(afterli).before(dragged)
         if (beforeli) $(beforeli).append(dragged)
 
-        setGameTrees($('#gamechooser ol > li').map(function(x) {
-            return x.data('gametree')
+        setGameTrees($('#gamechooser ol > li').get().map(function(x) {
+            return $(x).data('gametree')
         }))
 
         var newindex = getGameTrees().indexOf(currentTree)

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -1061,15 +1061,18 @@ function clearConsole() {
 }
 
 function wireLinks($container) {
-    $container.find('a').on('click', function() {
+    $container.find('a').on('click', function(e) {
         if ($(this).hasClass('external'))  {
             if (!shell) {
                 this.target = '_blank'
                 return true
             }
 
+            e.preventDefault()
             shell.openExternal(this.href)
         } else if ($(this).hasClass('movenumber')) {
+            e.preventDefault()
+
             var movenumber = +$(this).text().slice(1)
             setUndoable(true, 'Go Back')
             goToMainVariation()
@@ -1077,8 +1080,6 @@ function wireLinks($container) {
             var tp = gametree.navigate(getRootTree(), 0, movenumber)
             if (tp) setCurrentTreePosition.apply(null, tp.concat([true, true]))
         }
-
-        return false
     })
 
     $container.find('.coord').on('mouseenter', function() {
@@ -1569,7 +1570,7 @@ function showGameChooser(restoreScrollbarPos) {
         }
     })
 
-    $('#gamechooser').off('drop').on('drop', function(e) {
+    $('#gamechooser').off('drop').on('drop', function() {
         var dragged = $(this).data('dragging')
         $(this).data('dragging', null)
 

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -687,11 +687,11 @@ function prepareGameChooser() {
     $('#gamechooser > input').on('input', function() {
         var value = this.value
 
-        $('#gamechooser .games-list li:not(.add)').forEach(function(li) {
-            if (li.children('span').some(function(span) {
+        $('#gamechooser .games-list li:not(.add)').get().forEach(function(li) {
+            if ($(li).children('span').some(function(span) {
                 return span.attr('text').toLowerCase().indexOf(value.toLowerCase()) >= 0
-            })) li.removeClass('hide')
-            else li.addClass('hide')
+            })) $(li).removeClass('hide')
+            else $(li).addClass('hide')
         })
 
         var gamesList = $('#gamechooser .games-list')[0]
@@ -1442,7 +1442,7 @@ function closeScore() {
 function showPreferences() {
     // Load preferences
 
-    $('#preferences input[type="checkbox"]').forEach(function(el) {
+    $('#preferences input[type="checkbox"]').get().forEach(function(el) {
         el.checked = !!setting.get(el.name)
     })
 

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -954,8 +954,8 @@ function updateBoardLines() {
     $('#goban hr').get().forEach(function(line) {
         var v1 = $(line).data('v1'), v2 = $(line).data('v2')
         var mirrored = v2[0] < v1[0]
-        var $li1 = $('#goban').find('.pos_' + v1[0] + '-' + v1[1])
-        var $li2 = $('#goban').find('.pos_' + v2[0] + '-' + v2[1])
+        var $li1 = $('#goban .pos_' + v1.join('-'))
+        var $li2 = $('#goban .pos_' + v2.join('-'))
         var pos1 = $li1.position()
         var pos2 = $li2.position()
         var dy = pos2.top - pos1.top, dx = pos2.left - pos1.left

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -258,7 +258,7 @@ function setCommentText(text) {
 }
 
 function getCommentTitle() {
-    return $('#properties .edit .header input').eq(0).val()
+    return $('#properties .edit .header input').val()
 }
 
 function setCommentTitle(text) {
@@ -290,12 +290,12 @@ function setAnnotations(posstatus, posvalue, movestatus, movevalue) {
         $img.attr('src', '../img/ui/goodmove.svg')
             .attr('alt', 'Good move')
 
-    if (movevalue == 2) $img.alt = 'Very ' + $img.alt.toLowerCase()
-    $img.title = $img.alt
+    if (movevalue == 2) $img.attr('alt', 'Very ' + $img.attr('alt').toLowerCase())
+    $img.attr('title', $img.attr('alt'))
 
     // Set positional status
 
-    img = $header.find('img:nth-child(1)')
+    $img = $header.find('img:nth-child(1)')
 
     if (posstatus == null) $header.removeClass('positionstatus')
     else $header.addClass('positionstatus')
@@ -313,8 +313,8 @@ function setAnnotations(posstatus, posvalue, movestatus, movevalue) {
         $img.attr('src', '../img/ui/unclear.svg')
             .attr('alt', 'Unclear position')
 
-    if (posvalue == 2) $img.alt = 'Very ' + $img.alt.toLowerCase()
-    $img.title = $img.alt
+    if (posvalue == 2) $img.attr('alt', 'Very ' + $img.attr('alt').toLowerCase())
+    $img.attr('title', $img.attr('alt'))
 }
 
 function getSliderValue() {
@@ -760,7 +760,7 @@ function addEngineItem(name, path, args) {
             $('<input/>')
             .attr('type', 'text')
             .attr('placeholder', 'No arguments')
-            .attr('value', args)
+            .val(args)
         )
     ).append(
         $('<a class="remove"/>').on('click', function() {

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -99,7 +99,7 @@ function setShowLeftSidebar(show) {
     // Update scrollbars
     var view = $('#console .gm-scroll-view')[0]
     view.scrollTo(0, view.getScrollSize().y)
-    view.getElement('form:last-child input').focus()
+    view.find('form:last-child input').focus()
     $('#console').data('scrollbar').update()
 }
 
@@ -221,8 +221,8 @@ function setShowHotspot(bookmark) {
 
 function getCaptures() {
     return {
-        '-1': +$('#player_-1 .captures')[0].attr('text'),
-        '1': +$('#player_1 .captures')[0].attr('text')
+        '-1': +$('#player_-1 .captures').attr('text'),
+        '1': +$('#player_1 .captures').attr('text')
     }
 }
 
@@ -234,7 +234,7 @@ function setCaptures(captures) {
 }
 
 function getCurrentPlayer() {
-    return $('.currentplayer').eq(0).attr('src') == '../img/ui/blacktoplay.svg' ? 1 : -1
+    return $('.currentplayer').attr('src') == '../img/ui/blacktoplay.svg' ? 1 : -1
 }
 
 function setCurrentPlayer(sign) {
@@ -242,17 +242,17 @@ function setCurrentPlayer(sign) {
 }
 
 function getCommentText() {
-    return $('#properties textarea').val()[0]
+    return $('#properties textarea').val()
 }
 
 function setCommentText(text) {
     var html = helper.markdown(text)
-    var container = $('#properties .inner .comment')[0]
-    var textarea = $('#properties textarea')[0]
+    var $container = $('#properties .inner .comment')
+    var $textarea = $('#properties textarea')
 
-    if (textarea.val() != text) textarea.val(text)
-    container.attr('html', html)
-    wireLinks(container)
+    if ($textarea.val() != text) $textarea.val(text)
+    $container.attr('html', html)
+    wireLinks($container)
 }
 
 function getCommentTitle() {
@@ -268,7 +268,7 @@ function setCommentTitle(text) {
 
 function setAnnotations(posstatus, posvalue, movestatus, movevalue) {
     var header = $('#properties .inner .header')[0]
-    var img = header.getElement('img:nth-child(2)')
+    var img = header.find('img:nth-child(2)')
 
     // Set move status
 
@@ -293,7 +293,7 @@ function setAnnotations(posstatus, posvalue, movestatus, movevalue) {
 
     // Set positional status
 
-    img = header.getElement('img:nth-child(1)')
+    img = header.find('img:nth-child(1)')
 
     if (posstatus == null) header.removeClass('positionstatus')
     else header.addClass('positionstatus')
@@ -336,7 +336,7 @@ function setFindMode(pickMode) {
         if (pickMode != getFindMode()) closeDrawers()
         $('body').addClass('find')
 
-        var input = $('#find').getElement('input')
+        var input = $('#find').find('input')
         input.focus()
         input.select()
     } else {
@@ -347,11 +347,11 @@ function setFindMode(pickMode) {
 }
 
 function getFindText() {
-    return $('#find').getElement('input').value
+    return $('#find').find('input').value
 }
 
 function setFindText(text) {
-    $('#find').getElement('input').value = text
+    $('#find').find('input').value = text
 }
 
 function getEditMode() {
@@ -432,11 +432,11 @@ function setIndicatorVertex(vertex) {
 
 function setPreferencesTab(tab) {
     $('#preferences .tabs')[0]
-        .getElement('.current')
+        .find('.current')
         .removeClass('current')
-        .getParent()
-        .getElement('.' + tab)
-        .getParent()
+        .parent()
+        .find('.' + tab)
+        .parent()
         .addClass('current')
 
     var form = $('#preferences form')[0]
@@ -613,7 +613,7 @@ function prepareScrollbars() {
 function prepareResizers() {
     $('.verticalresizer').on('mousedown', function(e) {
         if (e.event.button != 0) return
-        this.getParent().data('initposx', [e.event.screenX, parseFloat(this.getParent().width())])
+        this.parent().data('initposx', [e.event.screenX, parseFloat(this.parent().width())])
     })
 
     $('#sidebar .horizontalresizer').on('mousedown', function(e) {
@@ -686,7 +686,7 @@ function prepareGameChooser() {
         var value = this.value
 
         $('#gamechooser .games-list li:not(.add)').forEach(function(li) {
-            if (li.getElements('span').some(function(span) {
+            if (li.children('span').some(function(span) {
                 return span.attr('text').toLowerCase().indexOf(value.toLowerCase()) >= 0
             })) li.removeClass('hide')
             else li.addClass('hide')
@@ -737,7 +737,7 @@ function addEngineItem(name, path, args) {
 
                     if (result) {
                         this.getParent('li')
-                            .getElement('h3 + p input')
+                            .find('h3 + p input')
                             .val(result[0])
                             .focus()
                     }
@@ -771,7 +771,7 @@ function addEngineItem(name, path, args) {
     )
 
     ul.grab(li)
-    li.getElement('h3 input').focus()
+    li.find('h3 input').focus()
 
     var enginesScrollbar = $('#preferences .engines-list')[0].data('scrollbar')
     if (enginesScrollbar) enginesScrollbar.update()
@@ -943,8 +943,8 @@ function updateBoardLines() {
     $('#goban hr').forEach(function(line) {
         var v1 = line.data('v1'), v2 = line.data('v2')
         var mirrored = v2[0] < v1[0]
-        var li1 = $('#goban').getElement('.pos_' + v1[0] + '-' + v1[1])
-        var li2 = $('#goban').getElement('.pos_' + v2[0] + '-' + v2[1])
+        var li1 = $('#goban').find('.pos_' + v1[0] + '-' + v1[1])
+        var li2 = $('#goban').find('.pos_' + v2[0] + '-' + v2[1])
         var pos1 = li1.getPosition($('#goban'))
         var pos2 = li2.getPosition($('#goban'))
         var dy = pos2.y - pos1.y, dx = pos2.x - pos1.x
@@ -1031,8 +1031,8 @@ function clearConsole() {
     $('#console').data('scrollbar').update()
 }
 
-function wireLinks(container) {
-    container.getElements('a').on('click', function() {
+function wireLinks($container) {
+    $container.children('a').on('click', function() {
         if (this.hasClass('external'))  {
             if (!shell) {
                 this.target = '_blank'
@@ -1052,7 +1052,7 @@ function wireLinks(container) {
         return false
     })
 
-    container.getElements('.coord').on('mouseenter', function() {
+    $container.children('.coord').on('mouseenter', function() {
         var v = getBoard().coord2vertex(this.attr('text'))
         showIndicator(v)
     }).on('mouseleave', function() {
@@ -1282,7 +1282,7 @@ function openGameMenu(element, event) {
                     ['Remove Game', 'Cancel'], 1
                 ) == 1) return
 
-                var index = element.getParent('ol').getElements('li div').indexOf(element)
+                var index = element.getParent('ol').children('li div').indexOf(element)
                 trees.splice(index, 1)
 
                 setGameTrees(trees)
@@ -1355,7 +1355,7 @@ function openAddGameMenu() {
     ]
 
     var menu = Menu.buildFromTemplate(template)
-    var button = $('#gamechooser').getElement('button[name="add"]')
+    var button = $('#gamechooser').find('button[name="add"]')
     var position = button.getPosition()
     menu.popup(remote.getCurrentWindow(), Math.round(position.x), Math.round(position.y + button.innerHeight()))
 }
@@ -1379,21 +1379,21 @@ function showGameInfo() {
         'result': 'RE'
     }
 
-    info.addClass('show').getElement('input[name="name_1"]').focus()
+    info.addClass('show').find('input[name="name_1"]').focus()
 
     for (var key in data) {
         var value = data[key]
-        info.getElement('input[name="' + key + '"]').val(value in rootNode ? rootNode[value][0] : '')
+        info.find('input[name="' + key + '"]').val(value in rootNode ? rootNode[value][0] : '')
     }
 
-    info.getElement('input[name="name_1"]').val(gametree.getPlayerName(1, tree, ''))
-    info.getElement('input[name="name_-1"]').val(gametree.getPlayerName(-1, tree, ''))
-    info.getElement('input[name="komi"]').val('KM' in rootNode ? +rootNode.KM[0] : '')
-    info.getElement('input[name="size-width"]').val(getBoard().width)
-    info.getElement('input[name="size-height"]').val(getBoard().height)
-    info.getElements('section .menu').removeClass('active').data('engineindex', -1)
+    info.find('input[name="name_1"]').val(gametree.getPlayerName(1, tree, ''))
+    info.find('input[name="name_-1"]').val(gametree.getPlayerName(-1, tree, ''))
+    info.find('input[name="komi"]').val('KM' in rootNode ? +rootNode.KM[0] : '')
+    info.find('input[name="size-width"]').val(getBoard().width)
+    info.find('input[name="size-height"]').val(getBoard().height)
+    info.children('section .menu').removeClass('active').data('engineindex', -1)
 
-    var handicap = info.getElement('select[name="handicap"]')
+    var handicap = info.find('select[name="handicap"]')
     if ('HA' in rootNode) handicap.selectedIndex = Math.max(0, +rootNode.HA[0] - 1)
     else handicap.selectedIndex = 0
 
@@ -1402,7 +1402,7 @@ function showGameInfo() {
         || ['AB', 'AW', 'W', 'B'].some(function(x) { return x in rootNode })
 
     handicap.disabled = disabled
-    info.getElements('input[name^="size-"]').attr('disabled', disabled)
+    info.children('input[name^="size-"]').attr('disabled', disabled)
     info.toggleClass('disabled', disabled)
 }
 
@@ -1418,7 +1418,7 @@ function showScore() {
 
     for (var sign = -1; sign <= 1; sign += 2) {
         var tr = $('#score tbody tr' + (sign < 0 ? ':last-child' : ''))[0]
-        var tds = tr.getElements('td')
+        var tds = tr.children('td')
 
         tds[0].attr('text', score['area_' + sign])
         tds[1].attr('text', score['territory_' + sign])
@@ -1489,16 +1489,16 @@ function showGameChooser(restoreScrollbarPos) {
             .grab(new Element('span.white', { text: 'White' }))
         ))
 
-        var gamename = li.getElement('span')
-        var black = li.getElement('.black').attr('text', gametree.getPlayerName(1, tree, 'Black'))
-        var white = li.getElement('.white').attr('text', gametree.getPlayerName(-1, tree, 'White'))
+        var gamename = li.find('span')
+        var black = li.find('.black').attr('text', gametree.getPlayerName(1, tree, 'Black'))
+        var white = li.find('.white').attr('text', gametree.getPlayerName(-1, tree, 'White'))
 
         if ('BR' in node) black.attr('title', node.BR[0])
         if ('WR' in node) white.attr('title', node.WR[0])
         if ('GN' in node) gamename.attr('text', node.GN[0]).attr('title', node.GN[0])
         else if ('EV' in node) gamename.attr('text', node.EV[0]).attr('title', node.EV[0])
 
-        li.data('gametree', tree).getElement('div').on('click', function() {
+        li.data('gametree', tree).find('div').on('click', function() {
             var link = this
             closeGameChooser()
             setTimeout(function() {

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -1033,15 +1033,15 @@ function clearConsole() {
 
 function wireLinks($container) {
     $container.children('a').on('click', function() {
-        if (this.hasClass('external'))  {
+        if ($(this).hasClass('external'))  {
             if (!shell) {
                 this.target = '_blank'
                 return true
             }
 
             shell.openExternal(this.href)
-        } else if (this.hasClass('movenumber')) {
-            var movenumber = +this.attr('text').slice(1)
+        } else if ($(this).hasClass('movenumber')) {
+            var movenumber = +$(this).attr('text').slice(1)
             setUndoable(true, 'Go Back')
             goToMainVariation()
 
@@ -1053,7 +1053,7 @@ function wireLinks($container) {
     })
 
     $container.children('.coord').on('mouseenter', function() {
-        var v = getBoard().coord2vertex(this.attr('text'))
+        var v = getBoard().coord2vertex($(this).attr('text'))
         showIndicator(v)
     }).on('mouseleave', function() {
         if (!getFindMode()) hideIndicator()
@@ -1519,10 +1519,10 @@ function showGameChooser(restoreScrollbarPos) {
         var x = e.event.clientX
         var middle = this.position().left + this.innerWidth() / 2
 
-        if (x <= middle - 10 && !this.hasClass('insertleft')) {
+        if (x <= middle - 10 && !$(this).hasClass('insertleft')) {
             $('#gamechooser ol li').removeClass('insertleft').removeClass('insertright')
             $(this).addClass('insertleft')
-        } else if (x > middle + 10 && !this.hasClass('insertright')) {
+        } else if (x > middle + 10 && !$(this).hasClass('insertright')) {
             $('#gamechooser ol li').removeClass('insertleft').removeClass('insertright')
             $(this).addClass('insertright')
         }

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -97,9 +97,9 @@ function setShowLeftSidebar(show) {
     setting.set('view.show_leftsidebar', show)
 
     // Update scrollbars
-    var view = $('#console .gm-scroll-view')[0]
-    view.scrollTo(0, view.getScrollSize().y)
-    view.find('form:last-child input').focus()
+    var $view = $('#console .gm-scroll-view')
+    $view.scrollTop($view.get(0).scrollHeight)
+    $view.find('form:last-child input').focus()
     $('#console').data('scrollbar').update()
 }
 
@@ -202,13 +202,13 @@ function setPropertiesHeight(height) {
 }
 
 function getPlayerName(sign) {
-    var el = $('#player_' + sign + ' .name')[0]
-    return [el.attr('text'), el.attr('title')]
+    var $el = $('#player_' + sign + ' .name')
+    return [$el.attr('text'), $el.attr('title')]
 }
 
 function setPlayerName(sign, name, tooltip) {
     if (name.trim() == '') name = sign > 0 ? 'Black' : 'White'
-    $('#player_' + sign + ' .name')[0].text(name).attr('title', tooltip)
+    $('#player_' + sign + ' .name').text(name).attr('title', tooltip)
 }
 
 function getShowHotspot() {
@@ -262,59 +262,59 @@ function getCommentTitle() {
 }
 
 function setCommentTitle(text) {
-    var input = $('#properties .edit .header input')[0]
+    var $input = $('#properties .edit .header input')
 
-    $('#properties .inner .header span')[0].text(text.trim() != '' ? text : getCurrentMoveInterpretation())
-    if (input.val() != text) input.val(text)
+    $('#properties .inner .header span').text(text.trim() != '' ? text : getCurrentMoveInterpretation())
+    if ($input.val() != text) $input.val(text)
 }
 
 function setAnnotations(posstatus, posvalue, movestatus, movevalue) {
-    var header = $('#properties .inner .header')[0]
-    var img = header.find('img:nth-child(2)')
+    var $header = $('#properties .inner .header')
+    var $img = $header.find('img:nth-child(2)')
 
     // Set move status
 
-    if (movestatus == null) header.removeClass('movestatus')
-    else header.addClass('movestatus')
+    if (movestatus == null) $header.removeClass('movestatus')
+    else $header.addClass('movestatus')
 
     if (movestatus == -1)
-        img.attr('src', '../img/ui/badmove.svg')
+        $img.attr('src', '../img/ui/badmove.svg')
             .attr('alt', 'Bad move')
     else if (movestatus == 0)
-        img.attr('src', '../img/ui/doubtfulmove.svg')
+        $img.attr('src', '../img/ui/doubtfulmove.svg')
             .attr('alt', 'Doubtful move')
     else if (movestatus == 1)
-        img.attr('src', '../img/ui/interestingmove.svg')
+        $img.attr('src', '../img/ui/interestingmove.svg')
             .attr('alt', 'Interesting move')
     else if (movestatus == 2)
-        img.attr('src', '../img/ui/goodmove.svg')
+        $img.attr('src', '../img/ui/goodmove.svg')
             .attr('alt', 'Good move')
 
-    if (movevalue == 2) img.alt = 'Very ' + img.alt.toLowerCase()
-    img.title = img.alt
+    if (movevalue == 2) $img.alt = 'Very ' + $img.alt.toLowerCase()
+    $img.title = $img.alt
 
     // Set positional status
 
-    img = header.find('img:nth-child(1)')
+    img = $header.find('img:nth-child(1)')
 
-    if (posstatus == null) header.removeClass('positionstatus')
-    else header.addClass('positionstatus')
+    if (posstatus == null) $header.removeClass('positionstatus')
+    else $header.addClass('positionstatus')
 
     if (posstatus == -1)
-        img.attr('src', '../img/ui/white.svg')
+        $img.attr('src', '../img/ui/white.svg')
             .attr('alt', 'Good for white')
     else if (posstatus == 0)
-        img.attr('src', '../img/ui/balance.svg')
+        $img.attr('src', '../img/ui/balance.svg')
             .attr('alt', 'Even position')
     else if (posstatus == 1)
-        img.attr('src', '../img/ui/black.svg')
+        $img.attr('src', '../img/ui/black.svg')
             .attr('alt', 'Good for black')
     else if (posstatus == -2)
-        img.attr('src', '../img/ui/unclear.svg')
+        $img.attr('src', '../img/ui/unclear.svg')
             .attr('alt', 'Unclear position')
 
-    if (posvalue == 2) img.alt = 'Very ' + img.alt.toLowerCase()
-    img.title = img.alt
+    if (posvalue == 2) $img.alt = 'Very ' + $img.alt.toLowerCase()
+    $img.title = $img.alt
 }
 
 function getSliderValue() {
@@ -365,7 +365,7 @@ function setEditMode(editMode) {
         closeDrawers()
         $('body').addClass('edit')
 
-        $('#properties textarea')[0].scrollTo(0, 0)
+        $('#properties textarea').eq(0).scrollTop(0)
     } else {
         $('#goban').data('edittool-data', null)
         $('body').removeClass('edit')
@@ -614,13 +614,13 @@ function prepareScrollbars() {
 
 function prepareResizers() {
     $('.verticalresizer').on('mousedown', function(e) {
-        if (e.event.button != 0) return
-        this.parent().data('initposx', [e.event.screenX, parseFloat(this.parent().width())])
+        if (e.button != 0) return
+        $(this).parent().data('initposx', [e.screenX, parseFloat($(this).parent().width())])
     })
 
     $('#sidebar .horizontalresizer').on('mousedown', function(e) {
-        if (e.event.button != 0) return
-        $('#sidebar').data('initposy', [e.event.screenY, getPropertiesHeight()])
+        if (e.button != 0) return
+        $('#sidebar').data('initposy', [e.screenY, getPropertiesHeight()])
         $('#properties').css('transition', 'none')
     })
 
@@ -656,13 +656,13 @@ function prepareResizers() {
 
         if (sidebarInitPosX) {
             var initX = sidebarInitPosX[0], initWidth = sidebarInitPosX[1]
-            var newwidth = Math.max(initWidth - e.event.screenX + initX, setting.get('view.sidebar_minwidth'))
+            var newwidth = Math.max(initWidth - e.screenX + initX, setting.get('view.sidebar_minwidth'))
 
             setSidebarWidth(newwidth)
             resizeBoard()
         } else if (leftSidebarInitPosX) {
             var initX = leftSidebarInitPosX[0], initWidth = leftSidebarInitPosX[1]
-            var newwidth = Math.max(initWidth + e.event.screenX - initX, setting.get('view.leftsidebar_minwidth'))
+            var newwidth = Math.max(initWidth + e.screenX - initX, setting.get('view.leftsidebar_minwidth'))
 
             setLeftSidebarWidth(newwidth)
             resizeBoard()
@@ -672,7 +672,7 @@ function prepareResizers() {
         } else if (initPosY) {
             var initY = initPosY[0], initHeight = initPosY[1]
             var newheight = Math.min(Math.max(
-                initHeight + (initY - e.event.screenY) * 100 / $('#sidebar').innerHeight(),
+                initHeight + (initY - e.screenY) * 100 / $('#sidebar').innerHeight(),
                 setting.get('view.properties_minheight')
             ), 100 - setting.get('view.properties_minheight'))
 
@@ -767,7 +767,7 @@ function addEngineItem(name, path, args) {
             this.parents('li').eq(0).remove()
             $('#preferences .engines-list')[0].data('scrollbar').update()
         }).append(
-            $('img')
+            $('<img/>')
             .attr('src', '../node_modules/octicons/svg/x.svg')
             .attr('height', 14)
         )
@@ -862,10 +862,10 @@ function buildBoard() {
             var vertex = [x, y]
             var $img = $('<img/>').attr('src', '../img/goban/stone_0.svg')
             var $li = $('<li/>')
-            .data('vertex', vertex)
-            .addClass('pos_' + x + '-' + y)
-            .addClass('shift_' + Math.floor(Math.random() * 9))
-            .addClass('random_' + Math.floor(Math.random() * 5))
+                .data('vertex', vertex)
+                .addClass('pos_' + x + '-' + y)
+                .addClass('shift_' + Math.floor(Math.random() * 9))
+                .addClass('random_' + Math.floor(Math.random() * 5))
 
             if (hoshi.some(function(v) { return helper.equals(v, vertex) }))
                 $li.addClass('hoshi')
@@ -889,7 +889,7 @@ function buildBoard() {
                     if (!$('#goban').data('mousedown')) return
 
                     $('#goban').data('mousedown', false)
-                    vertexClicked(this, e.event)
+                    vertexClicked(this, e)
                 }.bind(vertex))
                 .on('touchend', function(e) {
                     if (getEditMode() && ['line', 'arrow'].indexOf(getSelectedTool()) >= 0) {
@@ -899,13 +899,13 @@ function buildBoard() {
                 })
                 .on('mousemove', function(e) {
                     if (!$('#goban').data('mousedown')) return
-                    if (e.event.buttons == 0) return
+                    if (e.button != 0) return
 
                     drawLine(this)
                 }.bind(vertex))
                 .on('touchmove', function(e) {
                     e.preventDefault()
-                    drawLine(getEndTargetVertex(e.event))
+                    drawLine(getEndTargetVertex(e))
                 })
                 .on('mousedown', function() {
                     $('#goban').data('mousedown', true)
@@ -974,8 +974,8 @@ function resizeBoard() {
     var outerHeight = $('#main').outerHeight()
     var boardWidth = board.width
     var boardHeight = board.height
-    var width = helper.floorEven($('#main').width())
-    var height = helper.floorEven($('#main').height())
+    var width = helper.floorEven(outerWidth - $('#goban').outerWidth() + $('#goban').width())
+    var height = helper.floorEven(outerHeight - $('#goban').outerHeight() + $('#goban').height())
 
     if (getShowCoordinates()) {
         boardWidth += 2
@@ -993,10 +993,10 @@ function resizeBoard() {
     $('#goban > div').css('width', minX).css('height', minY)
         .css('margin-left', -minX / 2).css('margin-top', -minY / 2)
 
-    $('#goban .row, #goban .coordx').css('height', fieldsize).css('line-height', fieldsize)
+    $('#goban .row, #goban .coordx').css('height', fieldsize).css('line-height', fieldsize + 'px')
     $('#goban .row, #goban .coordx').css('margin-left', getShowCoordinates() ? fieldsize : 0)
 
-    $('#goban .coordy').css('width', fieldsize).css('top', fieldsize).css('line-height', fieldsize)
+    $('#goban .coordy').css('width', fieldsize).css('top', fieldsize).css('line-height', fieldsize + 'px')
     $('#goban .coordy:last-child').css('left', fieldsize * (board.width + 1))
 
     $('#goban li').css('width', fieldsize).css('height', fieldsize)
@@ -1023,8 +1023,8 @@ function showIndicator(vertex) {
 
 function hideIndicator() {
     $('#indicator')
-    .css('top', ' ')
-    .css('left', ' ')
+    .css('top', '')
+    .css('left', '')
     .data('vertex', null)
 }
 
@@ -1420,14 +1420,14 @@ function showScore() {
     var rootNode = getRootTree().nodes[0]
 
     for (var sign = -1; sign <= 1; sign += 2) {
-        var tr = $('#score tbody tr' + (sign < 0 ? ':last-child' : ''))[0]
-        var tds = tr.children('td')
+        var $tr = $('#score tbody tr' + (sign < 0 ? ':last-child' : ''))
+        var $tds = $tr.children('td')
 
-        tds[0].text(score['area_' + sign])
-        tds[1].text(score['territory_' + sign])
-        tds[2].text(score['captures_' + sign])
-        if (sign < 0) tds[3].text(getKomi())
-        tds[4].text(0)
+        $tds.eq(0).text(score['area_' + sign])
+        $tds.eq(1).text(score['territory_' + sign])
+        $tds.eq(2).text(score['captures_' + sign])
+        if (sign < 0) $tds.eq(3).text(getKomi())
+        $tds.eq(4).text(0)
 
         setScoringMethod(setting.get('scoring.method'))
     }
@@ -1509,8 +1509,8 @@ function showGameChooser(restoreScrollbarPos) {
                 setGameIndex($('#gamechooser ol li div').get().indexOf(link))
             }, 500)
         }).on('mouseup', function(e) {
-            if (e.event.button != 2) return
-            openGameMenu(this, e.event)
+            if (e.button != 2) return
+            openGameMenu(this, e)
         }).on('dragstart', function(e) {
             $('#gamechooser').data('dragging', $(this).parents('li').eq(0))
         })
@@ -1520,7 +1520,7 @@ function showGameChooser(restoreScrollbarPos) {
         e.preventDefault()
         if (!$('#gamechooser').data('dragging')) return
 
-        var x = e.event.clientX
+        var x = e.clientX
         var middle = $(this).position().left + $(this).innerWidth() / 2
 
         if (x <= middle - 10 && !$(this).hasClass('insertleft')) {
@@ -1556,7 +1556,7 @@ function showGameChooser(restoreScrollbarPos) {
 
     $('#gamechooser').addClass('show')
     $(window).trigger('resize')
-    $('#gamechooser .gm-scroll-view').get(0).scrollTo(0, scrollbarPos)
+    $('#gamechooser .gm-scroll-view').scrollTop(scrollbarPos)
 }
 
 function closeGameChooser() {

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -956,8 +956,8 @@ function updateBoardLines() {
         var mirrored = v2[0] < v1[0]
         var $li1 = $('#goban .pos_' + v1.join('-'))
         var $li2 = $('#goban .pos_' + v2.join('-'))
-        var pos1 = $li1.position()
-        var pos2 = $li2.position()
+        var pos1 = $li1.offset()
+        var pos2 = $li2.offset()
         var dy = pos2.top - pos1.top, dx = pos2.left - pos1.left
 
         var angle = Math.atan(dy / dx) * 180 / Math.PI
@@ -1026,10 +1026,10 @@ function showIndicator(vertex) {
 
     if ($li.length == 0) return
 
-    $('#indicator').css('top', $li.offset().top)
-    .css('left', $li.offset().left)
-    .css('height', $li.height())
-    .css('width', $li.width())
+    $('#indicator').css('top', Math.round($li.offset().top))
+    .css('left', Math.round($li.offset().left))
+    .css('height', Math.round($li.height()))
+    .css('width', Math.round($li.width()))
     .data('vertex', vertex)
 }
 
@@ -1544,7 +1544,7 @@ function showGameChooser(restoreScrollbarPos) {
         if (!$('#gamechooser').data('dragging')) return
 
         var x = e.clientX
-        var middle = $(this).position().left + $(this).width() / 2
+        var middle = $(this).offset().left + $(this).width() / 2
 
         if (x <= middle - 10 && !$(this).hasClass('insertleft')) {
             $('#gamechooser ol li').removeClass('insertleft').removeClass('insertright')

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -192,7 +192,7 @@ function setSidebarWidth(width) {
 }
 
 function getPropertiesHeight() {
-    return $('#properties').innerHeight() * 100 / $('#sidebar').innerHeight()
+    return $('#properties').height() * 100 / $('#sidebar').height()
 }
 
 function setPropertiesHeight(height) {
@@ -672,7 +672,7 @@ function prepareResizers() {
         } else if (initPosY) {
             var initY = initPosY[0], initHeight = initPosY[1]
             var newheight = Math.min(Math.max(
-                initHeight + (initY - e.screenY) * 100 / $('#sidebar').innerHeight(),
+                initHeight + (initY - e.screenY) * 100 / $('#sidebar').height(),
                 setting.get('view.properties_minheight')
             ), 100 - setting.get('view.properties_minheight'))
 
@@ -978,16 +978,27 @@ function resizeBoard() {
     var board = getBoard()
     if (!board) return
 
-    $('main').css('width', '').css('height', '')
-    var outerWidth = Math.round($('main').width())
-    var outerHeight = Math.round($('main').height())
-    if ((outerWidth - outerHeight) % 2 != 0)
-        $('main').css('width', outerWidth + 1)
+    var $main = $('main')
+    var $goban = $('#goban')
+
+    $main.css('width', '').css('height', '')
+    var outerWidth = Math.round($main.width())
+    var outerHeight = Math.round($main.height())
+
+    if (outerWidth % 2 != 0) outerWidth++
+    if (outerHeight % 2 != 0) outerHeight++
+    $main.css('width', outerWidth).css('height', outerHeight)
 
     var boardWidth = board.width
     var boardHeight = board.height
-    var width = helper.floorEven(outerWidth - $('#goban').outerWidth() + $('#goban').width())
-    var height = helper.floorEven(outerHeight - $('#goban').outerHeight() + $('#goban').height())
+    var width = helper.floorEven(outerWidth - parseFloat($goban.css('padding-left'))
+        - parseFloat($goban.css('padding-right'))
+        - parseFloat($goban.css('border-left-width'))
+        - parseFloat($goban.css('border-right-width')))
+    var height = helper.floorEven(outerHeight - parseFloat($goban.css('padding-top'))
+        - parseFloat($goban.css('padding-bottom'))
+        - parseFloat($goban.css('border-top-width'))
+        - parseFloat($goban.css('border-bottom-width')))
 
     if (getShowCoordinates()) {
         boardWidth += 2
@@ -998,21 +1009,24 @@ function resizeBoard() {
     var minX = fieldsize * boardWidth
     var minY = fieldsize * boardHeight
 
-    $('#goban').css('width', minX + outerWidth - width)
+    $goban.css('width', minX + outerWidth - width)
         .css('height', minY + outerHeight - height)
-        .css('margin-left', -(minX + outerWidth - width) / 2)
-        .css('margin-top', -(minY + outerHeight - height) / 2)
-    $('#goban > div').css('width', minX).css('height', minY)
-        .css('margin-left', -minX / 2).css('margin-top', -minY / 2)
+        .css('margin-left', -(minX + outerWidth - width) / 2 + 'px')
+        .css('margin-top', -(minY + outerHeight - height) / 2 + 'px')
+    $goban.children('div').css('width', minX).css('height', minY)
+        .css('margin-left', -minX / 2 + 'px').css('margin-top', -minY / 2 + 'px')
 
-    $('#goban .row, #goban .coordx').css('height', fieldsize).css('line-height', fieldsize + 'px')
-    $('#goban .row, #goban .coordx').css('margin-left', getShowCoordinates() ? fieldsize : 0)
+    $goban.find('.row, .coordx')
+    .css('height', fieldsize).css('line-height', fieldsize + 'px')
+    .css('margin-left', getShowCoordinates() ? fieldsize : 0)
 
-    $('#goban .coordy').css('width', fieldsize).css('top', fieldsize).css('line-height', fieldsize + 'px')
-    $('#goban .coordy:last-child').css('left', fieldsize * (board.width + 1))
+    $goban.find('.coordy')
+    .css('width', fieldsize).css('top', fieldsize).css('line-height', fieldsize + 'px')
+    .last()
+    .css('left', fieldsize * (board.width + 1))
 
-    $('#goban li').css('width', fieldsize).css('height', fieldsize)
-    $('#goban').css('font-size', fieldsize)
+    $goban.find('li').css('width', fieldsize).css('height', fieldsize)
+    $goban.css('font-size', fieldsize)
 
     setSliderValue.apply(null, getSliderValue())
     if (getIndicatorVertex()) showIndicator(getIndicatorVertex())
@@ -1224,7 +1238,7 @@ function openCommentMenu() {
     menu.popup(
         remote.getCurrentWindow(),
         Math.round($el.offset().left),
-        Math.round($el.offset().top + $el.innerHeight())
+        Math.round($el.offset().top + $el.height())
     )
 }
 
@@ -1268,7 +1282,7 @@ function openEnginesMenu($element, callback) {
     menu.popup(
         remote.getCurrentWindow(),
         Math.round($element.offset().left),
-        Math.round($element.offset().top + $element.innerHeight())
+        Math.round($element.offset().top + $element.height())
     )
 }
 
@@ -1382,7 +1396,7 @@ function openAddGameMenu() {
     menu.popup(
         remote.getCurrentWindow(),
         Math.round($button.offset().left),
-        Math.round($button.offset().top + $button.innerHeight())
+        Math.round($button.offset().top + $button.height())
     )
 }
 


### PR DESCRIPTION
Get rid of Mootools and use Sprint instead. This is the spiritual successor to #47.

### Preprocess

- [x] Remove `Element.store()` and `Element.retrieve()` calls
- [x] Remove `String.toInt()` calls
- [x] ~~Remove `Tween` methods~~

### Replace Mootools

- [x] Change `$` and `$$` calls
- [x] Change `Element.setStyle()`
- [x] Change dimension measuring
- [x] Change event handling
- [x] Change DOM manipulation
- [x] Fix board rounding errors regression
- [x] Testing

### Review

- [x] `index.js`
- [x] `index.view.js`
  - [x] `setAnnotations()`
  - [x] `buildBoard()`
  - [x] `resizeBoard()`

### Sprint

- [x] Add `.data()`
- [x] ~~Add `.clone()`~~
- [x] Avoid using `.(inner|outer)(Width|Height)()`