### PR TITLE
SVG on the fly

### DIFF
--- a/view/index.view.js
+++ b/view/index.view.js
@@ -1560,7 +1560,7 @@ function showGameChooser(restoreScrollbarPos) {
 
     for (var i = 0; i < trees.length; i++) {
         var tree = trees[i]
-        var $li = $('<li/>').data('tree', tree)
+        var $li = $('<li/>')
         var node = tree.nodes[0]
 
         $('#gamechooser ol').eq(0).append($li.append(
@@ -1647,7 +1647,7 @@ function showGameChooser(restoreScrollbarPos) {
         })
 
         updateElements.forEach(function(el) {
-            var tree = $(el).data('tree')
+            var tree = $(el).data('gametree')
             var tp = gametree.navigate(tree, 0, 30)
             if (!tp) tp = gametree.navigate(tree, 0, gametree.getCurrentHeight(tree) - 1)
 

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -1637,9 +1637,10 @@ function showGameChooser(restoreScrollbarPos) {
     // Load SVG images on the fly
 
     var updateSVG = function() {
+        var listBounds = $('#gamechooser').get(0).getBoundingClientRect()
+        
         var updateElements = $('#gamechooser ol li').get().filter(function(el) {
             var bounds = el.getBoundingClientRect()
-            var listBounds = $('#gamechooser').get(0).getBoundingClientRect()
 
             return !$(el).find('svg').length
                 && bounds.top < listBounds.bottom

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -640,11 +640,11 @@ function prepareScrollbars() {
         if (!$('#gamechooser').hasClass('show')) return
 
         var width = $('#gamechooser .games-list').width() - 20
-        var $lis = $('#gamechooser ol li')
+        var $svgs = $('#gamechooser ol li svg')
 
-        if ($lis.length == 0) return
+        if ($svgs.length == 0) $svgs = $('#gamechooser ol li')
 
-        var liwidth = $lis.eq(0).width() + 12 + 20
+        var liwidth = $svgs.width() + 12 + 20
         var count = Math.floor(width / liwidth)
 
         $('#gamechooser ol li').css('width', Math.floor(width / count) - 20)
@@ -1638,7 +1638,7 @@ function showGameChooser(restoreScrollbarPos) {
 
     var updateSVG = function() {
         var listBounds = $('#gamechooser').get(0).getBoundingClientRect()
-        
+
         var updateElements = $('#gamechooser ol li').get().filter(function(el) {
             var bounds = el.getBoundingClientRect()
 

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -1561,18 +1561,12 @@ function showGameChooser(restoreScrollbarPos) {
     for (var i = 0; i < trees.length; i++) {
         var tree = trees[i]
         var $li = $('<li/>')
-        var tp = gametree.navigate(tree, 0, 30)
-        if (!tp) tp = gametree.navigate(tree, 0, gametree.getCurrentHeight(tree) - 1)
-
-        var board = gametree.addBoard.apply(null, tp).nodes[tp[1]].board
-        var svg = board.getSvg(setting.get('gamechooser.thumbnail_size'))
         var node = tree.nodes[0]
 
         $('#gamechooser ol').eq(0).append($li.append(
             $('<div/>')
             .attr('draggable', 'true')
             .append($('<span/>'))
-            .append(svg)
             .append($('<span class="black"/>').text('Black'))
             .append($('<span class="white"/>').text('White'))
         ))

--- a/view/index.view.js
+++ b/view/index.view.js
@@ -1543,12 +1543,16 @@ function showGameChooser(restoreScrollbarPos) {
     if (restoreScrollbarPos == null)
         restoreScrollbarPos = true
 
-    var scrollbarPos = restoreScrollbarPos ? $('#gamechooser .gm-scroll-view').scrollTop() : 0
+    var $scrollContainer = $('#gamechooser .games-list')
+    if ($scrollContainer.hasClass('gm-scrollbar-container'))
+        $scrollContainer = $scrollContainer.find('.gm-scroll-view')
+
+    var scrollbarPos = restoreScrollbarPos ? $scrollContainer.scrollTop() : 0
 
     if (!restoreScrollbarPos || restoreScrollbarPos == 'top')
         scrollbarPos = 0
     else if (restoreScrollbarPos == 'bottom')
-        scrollbarPos = $('#gamechooser .gm-scroll-view').get(0).scrollHeight
+        scrollbarPos = $scrollContainer.get(0).scrollHeight
 
     closeDrawers()
 
@@ -1661,7 +1665,7 @@ function showGameChooser(restoreScrollbarPos) {
 
     $('#gamechooser').addClass('show')
     $(window).on('resize', updateSVG).trigger('resize')
-    $('#gamechooser .gm-scroll-view').on('scroll', updateSVG).scrollTop(scrollbarPos)
+    $scrollContainer.on('scroll', updateSVG).scrollTop(scrollbarPos)
 }
 
 function closeGameChooser() {


### PR DESCRIPTION
When there's a huge amount of games inside a SGF collection, it takes a long time to open the 'Manage Games...' dialog, mainly because Sabaki tries to generate preview images for all of the games at once. To alleviate this, we only generate preview images for the items that are visible, and update once we start scrolling or resizing the window.

Closes #125 