### PR TITLE
Global `sabaki` object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
   - "6"
-before_script:
-  - npm install -g mocha
 notifications:
   email:
     on_success: never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 **Fixed**
 
 * Fix arrow keys not working in open/save file dialog on macOS
+* Fix guess mode when an engine is attached
 
 ## [Sabaki v0.18.0][v0.18.0] (2016-09-18)
 

--- a/browser/index.js
+++ b/browser/index.js
@@ -1,4 +1,5 @@
 require('./ipc')
+window.sabaki = sabaki = {}
 
 const fs = require('fs')
 const {ipcRenderer, remote} = require('electron')
@@ -19,45 +20,45 @@ const gtp = require('../modules/gtp')
  * Getter & setter
  */
 
-function getGameTrees() {
+sabaki.getGameTrees = function() {
     let trees = $('body').data('gametrees')
-    return trees ? trees : [getRootTree()]
+    return trees ? trees : [sabaki.getRootTree()]
 }
 
-function setGameTrees(trees) {
+sabaki.setGameTrees = function(trees) {
     trees.forEach(tree => { tree.parent = null })
     $('body').data('gametrees', trees)
 }
 
-function getGameIndex() {
-    return getGameTrees().length == 1 ? 0 : $('body').data('gameindex')
+sabaki.getGameIndex = function() {
+    return sabaki.getGameTrees().length == 1 ? 0 : $('body').data('gameindex')
 }
 
-function setGameIndex(index) {
-    let trees = getGameTrees()
+sabaki.setGameIndex = function(index) {
+    let trees = sabaki.getGameTrees()
     $('body').data('gameindex', index)
 
-    setGameTrees(trees)
-    setRootTree(trees[index])
+    sabaki.setGameTrees(trees)
+    sabaki.setRootTree(trees[index])
     view.updateTitle()
-    setUndoable(false)
-    if (setting.get('game.goto_end_after_loading')) goToEnd()
+    sabaki.setUndoable(false)
+    if (setting.get('game.goto_end_after_loading')) sabaki.goToEnd()
 }
 
-function getRootTree() {
-    if (!getCurrentTreePosition()) return null
-    return getGameTrees()[getGameIndex()]
+sabaki.getRootTree = function() {
+    if (!sabaki.getCurrentTreePosition()) return null
+    return sabaki.getGameTrees()[sabaki.getGameIndex()]
 }
 
-function setRootTree(tree) {
+sabaki.setRootTree = function(tree) {
     if (tree.nodes.length == 0) return
 
-    let trees = getGameTrees()
-    trees[getGameIndex()] = tree
-    setGameTrees(trees)
+    let trees = sabaki.getGameTrees()
+    trees[sabaki.getGameIndex()] = tree
+    sabaki.setGameTrees(trees)
 
     tree.parent = null
-    setCurrentTreePosition(gametree.addBoard(tree), 0, true)
+    sabaki.setCurrentTreePosition(gametree.addBoard(tree), 0, true)
 
     view.setPlayerName(1,
         gametree.getPlayerName(1, tree, 'Black'),
@@ -69,15 +70,15 @@ function setRootTree(tree) {
     )
 }
 
-function getFileHash() {
+sabaki.getFileHash = function() {
     return $('body').data('filehash')
 }
 
-function getGraphMatrixDict() {
+sabaki.getGraphMatrixDict = function() {
     return $('#graph').data('graphmatrixdict')
 }
 
-function setGraphMatrixDict(matrixdict) {
+sabaki.setGraphMatrixDict = function(matrixdict) {
     if (!view.getShowSidebar()) return
 
     let s, graph
@@ -93,25 +94,25 @@ function setGraphMatrixDict(matrixdict) {
             s.graph.read(graph)
         }
     } catch(e) {
-        setGraphMatrixDict(matrixdict)
+        sabaki.setGraphMatrixDict(matrixdict)
     }
 
     $('#graph').data('graphmatrixdict', matrixdict)
 }
 
-function getCurrentTreePosition() {
+sabaki.getCurrentTreePosition = function() {
     return $('#goban').data('position')
 }
 
-function setCurrentTreePosition(tree, index, now, redraw, ignoreAutoplay) {
+sabaki.setCurrentTreePosition = function(tree, index, now, redraw, ignoreAutoplay) {
     if (!tree || view.getScoringMode() || view.getEstimatorMode()) return
-    if (!ignoreAutoplay && getAutoplaying()) setAutoplaying(false)
+    if (!ignoreAutoplay && sabaki.getAutoplaying()) sabaki.setAutoplaying(false)
 
     // Remove old graph node color
 
-    let oldGraphNode = getCurrentGraphNode()
-    let oldPos = getCurrentTreePosition()
-    let graphNode = getGraphNode(tree, index)
+    let oldGraphNode = sabaki.getCurrentGraphNode()
+    let oldPos = sabaki.getCurrentTreePosition()
+    let graphNode = sabaki.getGraphNode(tree, index)
 
     if (oldGraphNode && oldGraphNode != graphNode)
         oldGraphNode.color = oldGraphNode.originalColor
@@ -136,10 +137,10 @@ function setCurrentTreePosition(tree, index, now, redraw, ignoreAutoplay) {
 
     let node = tree.nodes[index]
 
-    updateSidebar(redraw, now)
+    sabaki.updateSidebar(redraw, now)
     view.setShowHotspot('HO' in node)
     gametree.addBoard(tree, index)
-    setBoard(node.board)
+    sabaki.setBoard(node.board)
 
     // Determine current player
 
@@ -154,19 +155,19 @@ function setCurrentTreePosition(tree, index, now, redraw, ignoreAutoplay) {
     view.setCurrentPlayer(currentplayer)
 }
 
-function getCurrentGraphNode() {
-    let pos = getCurrentTreePosition()
+sabaki.getCurrentGraphNode = function() {
+    let pos = sabaki.getCurrentTreePosition()
     if (!pos) return null
-    return getGraphNode(pos[0], pos[1])
+    return sabaki.getGraphNode(pos[0], pos[1])
 }
 
-function getGraphNode(tree, index) {
+sabaki.getGraphNode = function(tree, index) {
     let id = typeof tree === 'object' ? tree.id + '-' + index : tree
     let s = $('#graph').data('sigma')
     return s.graph.nodes(id)
 }
 
-function getSelectedTool() {
+sabaki.getSelectedTool = function() {
     let $li = $('#edit .selected')
     let tool = $li.attr('class').replace('selected', '').replace('-tool', '').trim()
 
@@ -179,24 +180,24 @@ function getSelectedTool() {
     }
 }
 
-function setSelectedTool(tool) {
+sabaki.setSelectedTool = function(tool) {
     if (!view.getEditMode()) {
         view.setEditMode(true)
-        if (getSelectedTool().indexOf(tool) >= 0) return
+        if (sabaki.getSelectedTool().indexOf(tool) >= 0) return
     }
 
     $('#goban').data('edittool-data', null)
     $('#edit .' + tool + '-tool a').trigger('click')
 }
 
-function getBoard() {
+sabaki.getBoard = function() {
     return $('#goban').data('board')
 }
 
-function setBoard(board) {
+sabaki.setBoard = function(board) {
     let $goban = $('#goban')
 
-    if (!getBoard() || getBoard().width != board.width || getBoard().height != board.height) {
+    if (!sabaki.getBoard() || sabaki.getBoard().width != board.width || sabaki.getBoard().height != board.height) {
         $goban.data('board', board)
         view.buildBoard()
     }
@@ -267,11 +268,11 @@ function setBoard(board) {
     view.updateBoardLines()
 }
 
-function getScoringMethod() {
+sabaki.getScoringMethod = function() {
     return $('#score .tabs .territory').hasClass('current') ? 'territory' : 'area'
 }
 
-function setScoringMethod(method) {
+sabaki.setScoringMethod = function(method) {
     $('#score .tabs li').removeClass('current')
     $('#score .tabs .' + method).addClass('current')
     $('#score tr > *').addClass('disabled')
@@ -301,27 +302,27 @@ function setScoringMethod(method) {
     $('#score .result').text(result)
 }
 
-function getKomi() {
-    let rootNode = getRootTree().nodes[0]
+sabaki.getKomi = function() {
+    let rootNode = sabaki.getRootTree().nodes[0]
     return 'KM' in rootNode ? +rootNode.KM[0] : 0
 }
 
-function getEngineName() {
+sabaki.getEngineName = function() {
     return $('#console').data('enginename')
 }
 
-function getEngineController() {
+sabaki.getEngineController = function() {
     return $('#console').data('controller')
 }
 
-function getEngineCommands() {
+sabaki.getEngineCommands = function() {
     return $('#console').data('commands')
 }
 
-function setUndoable(undoable, tooltip) {
+sabaki.setUndoable = function(undoable, tooltip) {
     if (undoable) {
-        let rootTree = gametree.clone(getRootTree())
-        let position = gametree.getLevel(...getCurrentTreePosition())
+        let rootTree = gametree.clone(sabaki.getRootTree())
+        let position = gametree.getLevel(...sabaki.getCurrentTreePosition())
         if (!tooltip) tooltip = 'Undo'
 
         $('#bar header .undo').attr('title', tooltip)
@@ -337,25 +338,25 @@ function setUndoable(undoable, tooltip) {
     }
 }
 
-function getHotspot() {
-    let [tree, index] = getCurrentTreePosition()
+sabaki.getHotspot = function() {
+    let [tree, index] = sabaki.getCurrentTreePosition()
     let node = tree.nodes[index]
 
     return 'HO' in node
 }
 
-function setHotspot(bookmark) {
-    let [tree, index] = getCurrentTreePosition()
+sabaki.setHotspot = function(bookmark) {
+    let [tree, index] = sabaki.getCurrentTreePosition()
     let node = tree.nodes[index]
 
     if (bookmark) node.HO = [1]
     else delete node.HO
 
-    updateGraph()
+    sabaki.updateGraph()
     view.setShowHotspot(bookmark)
 }
 
-function getEmptyGameTree() {
+sabaki.getEmptyGameTree = function() {
     let buffer = ';GM[1]FF[4]AP[' + app.getName() + ':' + app.getVersion() + ']'
         + 'CA[UTF-8]KM[' + setting.get('game.default_komi')
         + ']SZ[' + setting.get('game.default_board_size') + ']'
@@ -363,28 +364,28 @@ function getEmptyGameTree() {
     return sgf.parse(sgf.tokenize(buffer))
 }
 
-function getAutoplaying() {
+sabaki.getAutoplaying = function() {
     return view.getAutoplayMode() && $('#autoplay').hasClass('playing')
 }
 
-function setAutoplaying(playing) {
+sabaki.setAutoplaying = function(playing) {
     let autoplay = () => {
-        if (!getAutoplaying()) return
+        if (!sabaki.getAutoplaying()) return
 
-        let ntp = gametree.navigate(...getCurrentTreePosition(), 1)
+        let ntp = gametree.navigate(...sabaki.getCurrentTreePosition(), 1)
         if (!ntp) {
-            setAutoplaying(false)
+            sabaki.setAutoplaying(false)
             return
         }
 
         let node = ntp[0].nodes[ntp[1]]
 
         if (!node.B && !node.W) {
-            setCurrentTreePosition(...ntp, false, false, true)
+            sabaki.setCurrentTreePosition(...ntp, false, false, true)
         } else {
             let vertex = sgf.point2vertex(node.B ? node.B[0] : node.W[0])
             view.setCurrentPlayer(node.B ? 1 : -1)
-            makeMove(vertex, false, true)
+            sabaki.makeMove(vertex, false, true)
         }
 
         let id = setTimeout(autoplay, setting.get('autoplay.sec_per_move') * 1000)
@@ -405,7 +406,7 @@ function setAutoplaying(playing) {
  * Methods
  */
 
-function loadSettings() {
+sabaki.loadSettings = function() {
     $('head link.userstyle').attr('href', setting.stylesPath)
 
     $('#goban').toggleClass('fuzzy', setting.get('view.fuzzy_stone_placement'))
@@ -426,7 +427,7 @@ function loadSettings() {
     }
 }
 
-function prepareBars() {
+sabaki.prepareBars = function() {
     // Handle close buttons
 
     let bars = ['edit', 'guess', 'autoplay', 'scoring', 'estimator', 'find']
@@ -438,12 +439,12 @@ function prepareBars() {
 
     // Handle header bar
 
-    $('header .undo').on('click', () => undoBoard())
+    $('header .undo').on('click', () => sabaki.undoBoard())
     $('#headermenu').on('click', () => view.openHeaderMenu())
 
     // Handle autoplay bar
 
-    $('#autoplay .play').on('click', () => setAutoplaying(!getAutoplaying()))
+    $('#autoplay .play').on('click', () => sabaki.setAutoplaying(!sabaki.getAutoplaying()))
 
     // Handle scoring/estimator bar and drawer
 
@@ -452,12 +453,12 @@ function prepareBars() {
         view.showScore()
     })
 
-    $('#score .tabs .area a').on('click', () => setScoringMethod('area'))
-    $('#score .tabs .territory a').on('click', () => setScoringMethod('territory'))
+    $('#score .tabs .area a').on('click', () => sabaki.setScoringMethod('area'))
+    $('#score .tabs .territory a').on('click', () => sabaki.setScoringMethod('territory'))
     $('#score button[type="reset"]').on('click', () => view.closeScore())
     $('#score button[type="submit"]').on('click', evt => {
         evt.preventDefault()
-        commitScore()
+        sabaki.commitScore()
         view.closeScore()
     })
 
@@ -466,14 +467,14 @@ function prepareBars() {
     $('#find button').get().forEach((el, i) => {
         $(el).on('click', evt => {
             evt.preventDefault()
-            findMove(view.getIndicatorVertex(), view.getFindText(), 1 - i * 2)
+            sabaki.findMove(view.getIndicatorVertex(), view.getFindText(), 1 - i * 2)
         })
     })
 
     // Handle current player toggler
 
     $('.current-player').on('click', function() {
-        let [tree, index] = getCurrentTreePosition()
+        let [tree, index] = sabaki.getCurrentTreePosition()
         let node = tree.nodes[index]
         let intendedSign = 'B' in node ? -1 : +('W' in node)
         let sign = -view.getCurrentPlayer()
@@ -488,7 +489,7 @@ function prepareBars() {
     })
 }
 
-function prepareEditTools() {
+sabaki.prepareEditTools = function() {
     $('#edit ul a').on('click', function() {
         let $a = $(this)
         let $img = $a.find('img')
@@ -506,7 +507,7 @@ function prepareEditTools() {
     })
 }
 
-function prepareAutoplay() {
+sabaki.prepareAutoplay = function() {
     $('#autoplay input').on('input', function() {
         let value = Math.min(10, Math.max(1, +$(this).val()))
         value = Math.floor(value * 10) / 10
@@ -516,13 +517,13 @@ function prepareAutoplay() {
     })
 }
 
-function prepareSidebar() {
+sabaki.prepareSidebar = function() {
     // Prepare comments section
 
     $('#properties .header .edit-button').on('click', () => view.setEditMode(true))
     $('#properties .edit .header img').on('click', () => view.openCommentMenu())
 
-    $('#properties .edit .header input, #properties .edit textarea').on('input', () => commitCommentText())
+    $('#properties .edit .header input, #properties .edit textarea').on('input', () => sabaki.commitCommentText())
 
     // Prepare game graph
 
@@ -548,7 +549,7 @@ function prepareSidebar() {
     let getTreePos = evt => [evt.data.node.data[0], evt.data.node.data[1]]
 
     s.bind('clickNode', function(evt) {
-        setCurrentTreePosition(...getTreePos(evt), true)
+        sabaki.setCurrentTreePosition(...getTreePos(evt), true)
     }).bind('rightClickNode', function(evt) {
         let pos = [evt.data.captor.clientX, evt.data.captor.clientY]
         view.openNodeMenu(...getTreePos(evt), pos.map(x => Math.round(x)))
@@ -557,19 +558,19 @@ function prepareSidebar() {
     $container.data('sigma', s)
 }
 
-function prepareSlider() {
+sabaki.prepareSlider = function() {
     let $slider = $('#sidebar .slider .inner')
 
     let changeSlider = percentage => {
         percentage = Math.min(1, Math.max(0, percentage))
 
-        let level = Math.round((gametree.getHeight(getRootTree()) - 1) * percentage)
-        let tp = gametree.navigate(getRootTree(), 0, level)
-        if (!tp) tp = gametree.navigate(getRootTree(), 0, gametree.getCurrentHeight(getRootTree()) - 1)
+        let level = Math.round((gametree.getHeight(sabaki.getRootTree()) - 1) * percentage)
+        let tp = gametree.navigate(sabaki.getRootTree(), 0, level)
+        if (!tp) tp = gametree.navigate(sabaki.getRootTree(), 0, gametree.getCurrentHeight(sabaki.getRootTree()) - 1)
 
-        if (helper.equals(tp, getCurrentTreePosition())) return
-        setCurrentTreePosition(...tp)
-        updateSlider()
+        if (helper.equals(tp, sabaki.getCurrentTreePosition())) return
+        sabaki.setCurrentTreePosition(...tp)
+        sabaki.updateSlider()
     }
 
     let mouseMoveHandler = evt => {
@@ -605,7 +606,7 @@ function prepareSlider() {
 
     $('#sidebar .slider a').on('mousedown', function() {
         $(this).data('mousedown', true)
-        startAutoScroll($(this).hasClass('next') ? 1 : -1)
+        sabaki.startAutoScroll($(this).hasClass('next') ? 1 : -1)
     })
 
     $(document).on('mouseup', function() {
@@ -613,18 +614,18 @@ function prepareSlider() {
     })
 }
 
-function prepareDragDropFiles() {
+sabaki.prepareDragDropFiles = function() {
     $('body').on('dragover', function(evt) {
         evt.preventDefault()
     }).on('drop', function(evt) {
         evt.preventDefault()
 
         if (evt.dataTransfer.files.length == 0) return
-        loadFile(evt.dataTransfer.files[0].path)
+        sabaki.loadFile(evt.dataTransfer.files[0].path)
     })
 }
 
-function prepareConsole() {
+sabaki.prepareConsole = function() {
     $('#console form').on('submit', function(evt) {
         evt.preventDefault()
 
@@ -633,7 +634,7 @@ function prepareConsole() {
         $input.get(0).blur()
 
         let command = gtp.parseCommand($input.val())
-        sendGTPCommand(command)
+        sabaki.sendGTPCommand(command)
     })
 
     $('#console form input').on('keydown', function(evt) {
@@ -659,7 +660,7 @@ function prepareConsole() {
         } else if (evt.keyCode == 9) {
             // Tab
             let tokens = $(this).val().split(' ')
-            let commands = getEngineCommands()
+            let commands = sabaki.getEngineCommands()
             if (!commands) return
 
             let i = 0
@@ -667,7 +668,7 @@ function prepareConsole() {
             while (selection > tokens[i].length && selection.length != 0 && i < tokens.length - 1)
                 selection -= tokens[i++].length + 1
 
-            let result = fuzzyfinder.find(tokens[i], getEngineCommands())
+            let result = fuzzyfinder.find(tokens[i], sabaki.getEngineCommands())
             if (!result) return
             tokens[i] = result
 
@@ -681,10 +682,10 @@ function prepareConsole() {
     })
 }
 
-function prepareGameInfo() {
+sabaki.prepareGameInfo = function() {
     $('#info button[type="submit"]').on('click', function(evt) {
         evt.preventDefault()
-        commitGameInfo()
+        sabaki.commitGameInfo()
         view.closeGameInfo()
     })
 
@@ -849,7 +850,7 @@ function prepareGameInfo() {
     })
 }
 
-function preparePreferences() {
+sabaki.preparePreferences = function() {
     $('#preferences .tabs .general').on('click', () => view.setPreferencesTab('general'))
     $('#preferences .tabs .engines').on('click', () => view.setPreferencesTab('engines'))
 
@@ -860,15 +861,15 @@ function preparePreferences() {
 
     $('#preferences button[type="submit"]').on('click', evt => {
         evt.preventDefault()
-        commitPreferences()
+        sabaki.commitPreferences()
         view.closePreferences()
     })
 
     $('#preferences button[type="reset"]').on('click', () => view.closePreferences())
 }
 
-function generateFileHash() {
-    let trees = getGameTrees()
+sabaki.generateFileHash = function() {
+    let trees = sabaki.getGameTrees()
     let hash = ''
 
     for (let i = 0; i < trees.length; i++) {
@@ -878,11 +879,11 @@ function generateFileHash() {
     return hash
 }
 
-function updateFileHash() {
-    $('body').data('filehash', generateFileHash())
+sabaki.updateFileHash = function() {
+    $('body').data('filehash', sabaki.generateFileHash())
 }
 
-function loadEngines() {
+sabaki.loadEngines = function() {
     // Load engines list
 
     $('#preferences .engines-list ul').empty()
@@ -892,8 +893,8 @@ function loadEngines() {
     })
 }
 
-function attachEngine(exec, args, genMove) {
-    detachEngine()
+sabaki.attachEngine = function(exec, args, genMove) {
+    sabaki.detachEngine()
     view.setIsBusy(true)
 
     setTimeout(function() {
@@ -912,24 +913,24 @@ function attachEngine(exec, args, genMove) {
 
         $('#console').data('controller', controller)
 
-        sendGTPCommand(new gtp.Command(null, 'name'), true, function(response) {
+        sabaki.sendGTPCommand(new gtp.Command(null, 'name'), true, function(response) {
             $('#console').data('enginename', response.content)
         })
-        sendGTPCommand(new gtp.Command(null, 'version'))
-        sendGTPCommand(new gtp.Command(null, 'protocol_version'))
-        sendGTPCommand(new gtp.Command(null, 'list_commands'), true, function(response) {
+        sabaki.sendGTPCommand(new gtp.Command(null, 'version'))
+        sabaki.sendGTPCommand(new gtp.Command(null, 'protocol_version'))
+        sabaki.sendGTPCommand(new gtp.Command(null, 'list_commands'), true, function(response) {
             $('#console').data('commands', response.content.split('\n'))
         })
 
-        syncEngine()
+        sabaki.syncEngine()
         view.setIsBusy(false)
 
-        if (!!genMove) generateMove()
+        if (!!genMove) sabaki.generateMove()
     }, setting.get('gtp.attach_delay'))
 }
 
-function detachEngine() {
-    sendGTPCommand(new gtp.Command(null, 'quit'), true)
+sabaki.detachEngine = function() {
+    sabaki.sendGTPCommand(new gtp.Command(null, 'quit'), true)
 
     $('#console')
     .data('controller', null)
@@ -938,25 +939,25 @@ function detachEngine() {
     view.setIsBusy(false)
 }
 
-function syncEngine() {
-    let board = getBoard()
+sabaki.syncEngine = function() {
+    let board = sabaki.getBoard()
 
-    if (!getEngineController() || $('#console').data('boardhash') == board.getHash())
+    if (!sabaki.getEngineController() || $('#console').data('boardhash') == board.getHash())
         return
 
     if (!board.isSquare()) {
         view.showMessageBox('GTP engines don’t support non-square boards.', 'warning')
-        return detachEngine()
+        return sabaki.detachEngine()
     } else if (!board.isValid()) {
         view.showMessageBox('GTP engines don’t support invalid board positions.', 'warning')
-        return detachEngine()
+        return sabaki.detachEngine()
     }
 
     view.setIsBusy(true)
 
-    sendGTPCommand(new gtp.Command(null, 'clear_board'), true)
-    sendGTPCommand(new gtp.Command(null, 'boardsize', [board.width]), true)
-    sendGTPCommand(new gtp.Command(null, 'komi', [getKomi()]), true)
+    sabaki.sendGTPCommand(new gtp.Command(null, 'clear_board'), true)
+    sabaki.sendGTPCommand(new gtp.Command(null, 'boardsize', [board.width]), true)
+    sabaki.sendGTPCommand(new gtp.Command(null, 'komi', [sabaki.getKomi()]), true)
 
     // Replay
     for (let i = 0; i < board.width; i++) {
@@ -968,7 +969,7 @@ function syncEngine() {
             let color = sign > 0 ? 'B' : 'W'
             let point = board.vertex2coord(v)
 
-            sendGTPCommand(new gtp.Command(null, 'play', [color, point]), true)
+            sabaki.sendGTPCommand(new gtp.Command(null, 'play', [color, point]), true)
         }
     }
 
@@ -976,21 +977,21 @@ function syncEngine() {
     view.setIsBusy(false)
 }
 
-function makeMove(vertex, sendCommand = null, ignoreAutoplay = false) {
+sabaki.makeMove = function(vertex, sendCommand = null, ignoreAutoplay = false) {
     if (!view.getPlayMode() && !view.getAutoplayMode() && !view.getGuessMode()) return
-    if (sendCommand == null) sendCommand = getEngineController() != null
+    if (sendCommand == null) sendCommand = sabaki.getEngineController() != null
 
-    let pass = !getBoard().hasVertex(vertex)
-    if (!pass && getBoard().arrangement[vertex] != 0) return
+    let pass = !sabaki.getBoard().hasVertex(vertex)
+    if (!pass && sabaki.getBoard().arrangement[vertex] != 0) return
 
-    let position = getCurrentTreePosition()
+    let position = sabaki.getCurrentTreePosition()
     let tree = position[0], index = position[1]
     let sign = view.getCurrentPlayer()
     let color = sign > 0 ? 'B' : 'W'
     let capture = false, suicide = false
     let createNode = true
 
-    if (sendCommand) syncEngine()
+    if (sendCommand) sabaki.syncEngine()
 
     if (!pass) {
         // Check for ko
@@ -999,7 +1000,7 @@ function makeMove(vertex, sendCommand = null, ignoreAutoplay = false) {
             let ko = false
 
             if (tp) {
-                let hash = getBoard().makeMove(sign, vertex).getHash()
+                let hash = sabaki.getBoard().makeMove(sign, vertex).getHash()
                 ko = tp[0].nodes[tp[1]].board.getHash() == hash
             }
 
@@ -1011,16 +1012,16 @@ function makeMove(vertex, sendCommand = null, ignoreAutoplay = false) {
             ) != 0) return
         }
 
-        let vertexNeighbors = getBoard().getNeighbors(vertex)
+        let vertexNeighbors = sabaki.getBoard().getNeighbors(vertex)
 
         // Check for suicide
         capture = vertexNeighbors
-            .some(v => getBoard().arrangement[v] == -sign && getBoard().getLiberties(v).length == 1)
+            .some(v => sabaki.getBoard().arrangement[v] == -sign && sabaki.getBoard().getLiberties(v).length == 1)
 
         suicide = !capture
-        && vertexNeighbors.filter(v => getBoard().arrangement[v] == sign)
-            .every(v =>getBoard().getLiberties(v).length == 1)
-        && vertexNeighbors.filter(v => getBoard().arrangement[v] == 0).length == 0
+        && vertexNeighbors.filter(v => sabaki.getBoard().arrangement[v] == sign)
+            .every(v =>sabaki.getBoard().getLiberties(v).length == 1)
+        && vertexNeighbors.filter(v => sabaki.getBoard().arrangement[v] == 0).length == 0
 
         if (suicide && setting.get('game.show_suicide_warning')) {
             if (view.showMessageBox(
@@ -1049,7 +1050,7 @@ function makeMove(vertex, sendCommand = null, ignoreAutoplay = false) {
         node[color] = [sgf.vertex2point(vertex)]
         tree.nodes.push(node)
 
-        setCurrentTreePosition(tree, tree.nodes.length - 1, null, null, ignoreAutoplay)
+        sabaki.setCurrentTreePosition(tree, tree.nodes.length - 1, null, null, ignoreAutoplay)
     } else {
         if (index != tree.nodes.length - 1) {
             // Search for next move
@@ -1059,7 +1060,7 @@ function makeMove(vertex, sendCommand = null, ignoreAutoplay = false) {
                 && helper.equals(sgf.point2vertex(nextNode[color][0]), vertex)
 
             if (moveExists) {
-                setCurrentTreePosition(tree, index + 1, null, null, ignoreAutoplay)
+                sabaki.setCurrentTreePosition(tree, index + 1, null, null, ignoreAutoplay)
                 createNode = false
             }
         } else {
@@ -1072,7 +1073,7 @@ function makeMove(vertex, sendCommand = null, ignoreAutoplay = false) {
             })
 
             if (variations.length > 0) {
-                setCurrentTreePosition(gametree.addBoard(variations[0]), 0, null, null, ignoreAutoplay)
+                sabaki.setCurrentTreePosition(gametree.addBoard(variations[0]), 0, null, null, ignoreAutoplay)
                 createNode = false
             }
         }
@@ -1080,7 +1081,7 @@ function makeMove(vertex, sendCommand = null, ignoreAutoplay = false) {
         if (createNode) {
             // Create variation
 
-            let updateRoot = tree == getRootTree()
+            let updateRoot = tree == sabaki.getRootTree()
             let splitted = gametree.splitTree(tree, index)
             let newtree = gametree.new()
             let node = {}
@@ -1093,8 +1094,8 @@ function makeMove(vertex, sendCommand = null, ignoreAutoplay = false) {
             splitted.current = splitted.subtrees.length - 1
 
             gametree.addBoard(newtree, newtree.nodes.length - 1)
-            if (updateRoot) setRootTree(splitted)
-            setCurrentTreePosition(newtree, 0, null, null, ignoreAutoplay)
+            if (updateRoot) sabaki.setRootTree(splitted)
+            sabaki.setCurrentTreePosition(newtree, 0, null, null, ignoreAutoplay)
         }
     }
 
@@ -1114,14 +1115,14 @@ function makeMove(vertex, sendCommand = null, ignoreAutoplay = false) {
 
     // Remove undo information
 
-    setUndoable(false)
+    sabaki.setUndoable(false)
 
     // Enter scoring mode when two consecutive passes
 
     let enterScoring = false
 
     if (pass && createNode) {
-        let tp = getCurrentTreePosition()
+        let tp = sabaki.getCurrentTreePosition()
         let ptp = gametree.navigate(...tp, -1)
 
         if (ptp) {
@@ -1139,17 +1140,17 @@ function makeMove(vertex, sendCommand = null, ignoreAutoplay = false) {
     // Handle GTP engine
 
     if (sendCommand && !enterScoring) {
-        let command = new gtp.Command(null, 'play', [color, pass ? 'pass' : getBoard().vertex2coord(vertex)])
-        sendGTPCommand(command, true)
+        let command = new gtp.Command(null, 'play', [color, pass ? 'pass' : sabaki.getBoard().vertex2coord(vertex)])
+        sabaki.sendGTPCommand(command, true)
 
-        $('#console').data('boardhash', getBoard().getHash())
+        $('#console').data('boardhash', sabaki.getBoard().getHash())
 
         view.setIsBusy(true)
-        setTimeout(() => generateMove(true), setting.get('gtp.move_delay'))
+        setTimeout(() => sabaki.generateMove(true), setting.get('gtp.move_delay'))
     }
 }
 
-function makeResign(sign) {
+sabaki.makeResign = function(sign) {
     if (!sign) sign = view.getCurrentPlayer()
 
     view.showGameInfo()
@@ -1157,11 +1158,11 @@ function makeResign(sign) {
     $('#info input[name="result"]').val(player + '+Resign')
 }
 
-function useTool(vertex, evt) {
-    let [tree, index] = getCurrentTreePosition()
+sabaki.useTool = function(vertex, evt) {
+    let [tree, index] = sabaki.getCurrentTreePosition()
     let node = tree.nodes[index]
-    let tool = getSelectedTool()
-    let board = getBoard()
+    let tool = sabaki.getSelectedTool()
+    let board = sabaki.getBoard()
     let dictionary = {
         cross: 'MA',
         triangle: 'TR',
@@ -1175,7 +1176,7 @@ function useTool(vertex, evt) {
         if ('B' in node || 'W' in node || gametree.navigate(tree, index, 1)) {
             // New variation needed
 
-            let updateRoot = tree == getRootTree()
+            let updateRoot = tree == sabaki.getRootTree()
             let splitted = gametree.splitTree(tree, index)
 
             if (splitted != tree || splitted.subtrees.length != 0) {
@@ -1188,7 +1189,7 @@ function useTool(vertex, evt) {
             index = tree.nodes.length
             tree.nodes.push(node)
 
-            if (updateRoot) setRootTree(splitted)
+            if (updateRoot) sabaki.setRootTree(splitted)
         }
 
         let sign = tool.indexOf('_1') != -1 ? 1 : -1
@@ -1344,12 +1345,12 @@ function useTool(vertex, evt) {
         })
     }
 
-    setUndoable(false)
-    setCurrentTreePosition(tree, index)
+    sabaki.setUndoable(false)
+    sabaki.setCurrentTreePosition(tree, index)
 }
 
-function drawLine(vertex) {
-    let tool = getSelectedTool()
+sabaki.drawLine = function(vertex) {
+    let tool = sabaki.getSelectedTool()
 
     if (!vertex || !view.getEditMode() || tool != 'line' && tool != 'arrow') return
 
@@ -1364,21 +1365,21 @@ function drawLine(vertex) {
     view.updateBoardLines()
 }
 
-function findPosition(step, condition) {
+sabaki.findPosition = function(step, condition) {
     if (isNaN(step)) step = 1
     else step = step >= 0 ? 1 : -1
 
     view.setIsBusy(true)
 
     setTimeout(() => {
-        let tp = getCurrentTreePosition()
+        let tp = sabaki.getCurrentTreePosition()
         let iterator = gametree.makeNodeIterator(...tp)
 
         while (true) {
             tp = step >= 0 ? iterator.next() : iterator.prev()
 
             if (!tp) {
-                let root = getRootTree()
+                let root = sabaki.getRootTree()
 
                 if (step == 1) {
                     tp = [root, 0]
@@ -1390,23 +1391,23 @@ function findPosition(step, condition) {
                 iterator = gametree.makeNodeIterator(...tp)
             }
 
-            if (helper.equals(tp, getCurrentTreePosition()) || condition(...tp)) break
+            if (helper.equals(tp, sabaki.getCurrentTreePosition()) || condition(...tp)) break
         }
 
-        setCurrentTreePosition(...tp)
+        sabaki.setCurrentTreePosition(...tp)
         view.setIsBusy(false)
     }, setting.get('find.delay'))
 }
 
-function findBookmark(step) {
-    findPosition(step, (tree, index) => 'HO' in tree.nodes[index])
+sabaki.findBookmark = function(step) {
+    sabaki.findPosition(step, (tree, index) => 'HO' in tree.nodes[index])
 }
 
-function findMove(vertex, text, step) {
+sabaki.findMove = function(vertex, text, step) {
     if (vertex == null && text.trim() == '') return
     let point = vertex ? sgf.vertex2point(vertex) : null
 
-    findPosition(step, (tree, index) => {
+    sabaki.findPosition(step, (tree, index) => {
         let node = tree.nodes[index]
         let cond = (prop, value) => prop in node
             && node[prop][0].toLowerCase().indexOf(value.toLowerCase()) >= 0
@@ -1416,40 +1417,40 @@ function findMove(vertex, text, step) {
     })
 }
 
-function vertexClicked(vertex, evt) {
+sabaki.vertexClicked = function(vertex, evt) {
     view.closeGameInfo()
 
     if (view.getScoringMode() || view.getEstimatorMode()) {
         if ($('#score').hasClass('show')) return
         if (evt.button != 0) return
-        if (getBoard().arrangement[vertex] == 0) return
+        if (sabaki.getBoard().arrangement[vertex] == 0) return
 
         let dead = !$('#goban .pos_' + vertex.join('-')).hasClass('dead')
-        let stones = view.getEstimatorMode() ? getBoard().getChain(vertex) : getBoard().getRelatedChains(vertex)
+        let stones = view.getEstimatorMode() ? sabaki.getBoard().getChain(vertex) : sabaki.getBoard().getRelatedChains(vertex)
 
         stones.forEach(v => {
             $('#goban .pos_' + v.join('-')).toggleClass('dead', dead)
         })
 
-        updateAreaMap(view.getEstimatorMode())
+        sabaki.updateAreaMap(view.getEstimatorMode())
     } else if (view.getEditMode()) {
         if (evt.ctrlKey) {
-            let coord = getBoard().vertex2coord(vertex)
+            let coord = sabaki.getBoard().vertex2coord(vertex)
 
             view.setCommentText([view.getCommentText().trim(), coord].join(' ').trim())
-            commitCommentText()
+            sabaki.commitCommentText()
         } else {
-            useTool(vertex, evt)
+            sabaki.useTool(vertex, evt)
         }
     } else if (view.getFindMode()) {
         if (evt.button != 0) return
 
         view.setIndicatorVertex(vertex)
-        findMove(view.getIndicatorVertex(), view.getFindText(), 1)
+        sabaki.findMove(view.getIndicatorVertex(), view.getFindText(), 1)
     } else if (view.getGuessMode()) {
         if (evt.button != 0) return
 
-        let tp = gametree.navigate(...getCurrentTreePosition(), 1)
+        let tp = gametree.navigate(...sabaki.getCurrentTreePosition(), 1)
         if (!tp) {
             view.setGuessMode(false)
             return
@@ -1466,7 +1467,7 @@ function vertexClicked(vertex, evt) {
 
         let color = view.getCurrentPlayer() > 0 ? 'B' : 'W'
         let nextVertex = sgf.point2vertex(nextNode[color][0])
-        let board = getBoard()
+        let board = sabaki.getBoard()
 
         if (!board.hasVertex(nextVertex)) {
             view.setGuessMode(false)
@@ -1474,7 +1475,7 @@ function vertexClicked(vertex, evt) {
         }
 
         if (vertex[0] == nextVertex[0] && vertex[1] == nextVertex[1]) {
-            makeMove(vertex)
+            sabaki.makeMove(vertex)
         } else {
             if (board.arrangement[vertex] != 0) return
             if ($('#goban .pos_' + vertex.join('-')).hasClass('paint_1')) return
@@ -1495,26 +1496,26 @@ function vertexClicked(vertex, evt) {
         // Playing mode
 
         if (evt.button != 0) return
-        let board = getBoard()
+        let board = sabaki.getBoard()
 
         if (board.arrangement[vertex] == 0) {
-            makeMove(vertex)
+            sabaki.makeMove(vertex)
             view.closeDrawers()
         } else if (vertex in board.markups
         && board.markups[vertex][0] == 'point'
         && setting.get('edit.click_currentvertex_to_remove')) {
-            removeNode(...getCurrentTreePosition())
+            sabaki.removeNode(...sabaki.getCurrentTreePosition())
         }
     }
 }
 
-function updateSidebar(redraw = false, now = false) {
+sabaki.updateSidebar = function(redraw = false, now = false) {
     clearTimeout($('#sidebar').data('updatesidebarid'))
 
-    let [tree, index] = getCurrentTreePosition()
+    let [tree, index] = sabaki.getCurrentTreePosition()
 
     $('#sidebar').data('updatesidebarid', setTimeout(() => {
-        if (!helper.equals(getCurrentTreePosition(), [tree, index]))
+        if (!helper.equals(sabaki.getCurrentTreePosition(), [tree, index]))
             return
 
         // Set current path
@@ -1527,32 +1528,32 @@ function updateSidebar(redraw = false, now = false) {
 
         // Update
 
-        updateSlider()
-        updateCommentText()
-        if (redraw) updateGraph()
-        else centerGraphCameraAt(getCurrentGraphNode())
+        sabaki.updateSlider()
+        sabaki.updateCommentText()
+        if (redraw) sabaki.updateGraph()
+        else sabaki.centerGraphCameraAt(sabaki.getCurrentGraphNode())
     }, now ? 0 : setting.get('graph.delay')))
 }
 
-function updateGraph() {
-    if (!view.getShowSidebar() || !getCurrentTreePosition()) return
+sabaki.updateGraph = function() {
+    if (!view.getShowSidebar() || !sabaki.getCurrentTreePosition()) return
 
-    setGraphMatrixDict(gametree.tree2matrixdict(getRootTree()))
-    centerGraphCameraAt(getCurrentGraphNode())
+    sabaki.setGraphMatrixDict(gametree.tree2matrixdict(sabaki.getRootTree()))
+    sabaki.centerGraphCameraAt(sabaki.getCurrentGraphNode())
 }
 
-function updateSlider() {
+sabaki.updateSlider = function() {
     if (!view.getShowSidebar()) return
 
-    let [tree, index] = getCurrentTreePosition()
-    let total = gametree.getHeight(getRootTree()) - 1
+    let [tree, index] = sabaki.getCurrentTreePosition()
+    let total = gametree.getHeight(sabaki.getRootTree()) - 1
     let relative = gametree.getLevel(tree, index)
 
     view.setSliderValue(total == 0 ? 0 : relative * 100 / total, relative)
 }
 
-function updateCommentText() {
-    let [tree, index] = getCurrentTreePosition()
+sabaki.updateCommentText = function() {
+    let [tree, index] = sabaki.getCurrentTreePosition()
     let node = tree.nodes[index]
 
     view.setCommentText('C' in node ? node.C[0] : '')
@@ -1576,8 +1577,8 @@ function updateCommentText() {
     $('#properties').data('scrollbar').update()
 }
 
-function updateAreaMap(useEstimateMap) {
-    let board = getBoard().clone()
+sabaki.updateAreaMap = function(useEstimateMap) {
+    let board = sabaki.getBoard().clone()
 
     $('#goban .row li.dead').get().forEach(li => {
         if ($(li).hasClass('sign_1')) board.captures['-1']++
@@ -1599,7 +1600,7 @@ function updateAreaMap(useEstimateMap) {
 
         if ($falsedead.length > 0) {
             $falsedead.removeClass('dead')
-            return updateAreaMap()
+            return sabaki.updateAreaMap()
         }
     }
 
@@ -1608,8 +1609,8 @@ function updateAreaMap(useEstimateMap) {
     .data('finalboard', board)
 }
 
-function commitCommentText() {
-    let [tree, index] = getCurrentTreePosition()
+sabaki.commitCommentText = function() {
+    let [tree, index] = sabaki.getCurrentTreePosition()
     let node = tree.nodes[index]
     let title = view.getCommentTitle()
     let comment = view.getCommentText()
@@ -1620,12 +1621,12 @@ function commitCommentText() {
     if (title != '') node.N = [title]
     else delete node.N
 
-    updateSidebar(true)
-    setUndoable(false)
+    sabaki.updateSidebar(true)
+    sabaki.setUndoable(false)
 }
 
-function commitGameInfo() {
-    let rootNode = getRootTree().nodes[0]
+sabaki.commitGameInfo = function() {
+    let rootNode = sabaki.getRootTree().nodes[0]
     let $info = $('#info')
 
     let data = {
@@ -1646,11 +1647,11 @@ function commitGameInfo() {
     }
 
     view.setPlayerName(1,
-        gametree.getPlayerName(1, getRootTree(), 'Black'),
+        gametree.getPlayerName(1, sabaki.getRootTree(), 'Black'),
         'BR' in rootNode ? rootNode.BR[0] : ''
     )
     view.setPlayerName(-1,
-        gametree.getPlayerName(-1, getRootTree(), 'White'),
+        gametree.getPlayerName(-1, sabaki.getRootTree(), 'White'),
         'WR' in rootNode ? rootNode.WR[0] : ''
     )
 
@@ -1677,24 +1678,24 @@ function commitGameInfo() {
     let handicap = $handicapInput.get(0).selectedIndex
 
     if (!$handicapInput.get(0).disabled) {
-        setCurrentTreePosition(getRootTree(), 0)
+        sabaki.setCurrentTreePosition(sabaki.getRootTree(), 0)
 
         if (handicap == 0) {
             delete rootNode.AB
             delete rootNode.HA
         } else {
-            let board = getBoard()
+            let board = sabaki.getBoard()
             let stones = board.getHandicapPlacement(handicap + 1)
 
             rootNode.HA = ['' + stones.length]
             rootNode.AB = stones.map(sgf.vertex2point)
         }
 
-        setCurrentTreePosition(getRootTree(), 0)
+        sabaki.setCurrentTreePosition(sabaki.getRootTree(), 0)
     }
 
-    setUndoable(false)
-    updateSidebar()
+    sabaki.setUndoable(false)
+    sabaki.updateSidebar()
 
     // Update engine
 
@@ -1708,28 +1709,28 @@ function commitGameInfo() {
 
         if (max >= 0) {
             let engine = engines[max]
-            attachEngine(engine.path, engine.args, view.getCurrentPlayer() == sign)
+            sabaki.attachEngine(engine.path, engine.args, view.getCurrentPlayer() == sign)
         } else {
-            detachEngine()
+            sabaki.detachEngine()
         }
     } else {
         // Update komi
 
         let command = new gtp.Command(null, 'komi', [komi])
-        sendGTPCommand(command, true)
+        sabaki.sendGTPCommand(command, true)
     }
 }
 
-function commitScore() {
+sabaki.commitScore = function() {
     let result = $('#score .result').text()
 
     view.showGameInfo()
     $('#info input[name="result"]').val(result)
 
-    setUndoable(false)
+    sabaki.setUndoable(false)
 }
 
-function commitPreferences() {
+sabaki.commitPreferences = function() {
     // Save general preferences
 
     $('#preferences input[type="checkbox"]').get()
@@ -1754,18 +1755,18 @@ function commitPreferences() {
     })
 
     setting.save()
-    loadEngines()
+    sabaki.loadEngines()
 
     ipcRenderer.send('build-menu')
 }
 
-function sendGTPCommand(command, ignoreBlocked = false, callback = () => {}) {
-    if (!getEngineController()) {
+sabaki.sendGTPCommand = function(command, ignoreBlocked = false, callback = () => {}) {
+    if (!sabaki.getEngineController()) {
         $('#console form:last-child input').val('')
         return
     }
 
-    let controller = getEngineController()
+    let controller = sabaki.getEngineController()
     let $container = $('#console .inner')
     let $oldform = $container.find('form:last-child')
     let $form = $oldform.clone(true)
@@ -1806,40 +1807,40 @@ function sendGTPCommand(command, ignoreBlocked = false, callback = () => {}) {
     }
 }
 
-function generateMove(ignoreBusy = false) {
-    if (!getEngineController() || !ignoreBusy && view.getIsBusy()) return
+sabaki.generateMove = function(ignoreBusy = false) {
+    if (!sabaki.getEngineController() || !ignoreBusy && view.getIsBusy()) return
 
     view.closeDrawers()
-    syncEngine()
+    sabaki.syncEngine()
     view.setIsBusy(true)
 
     let color = view.getCurrentPlayer() > 0 ? 'B' : 'W'
     let opponent = view.getCurrentPlayer() > 0 ? 'W' : 'B'
 
-    sendGTPCommand(new gtp.Command(null, 'genmove', [color]), true, r => {
+    sabaki.sendGTPCommand(new gtp.Command(null, 'genmove', [color]), true, r => {
         view.setIsBusy(false)
         if (r.content.toLowerCase() == 'resign') {
-            view.showMessageBox(getEngineName() + ' has resigned.')
-            getRootTree().nodes[0].RE = [opponent + '+Resign']
+            view.showMessageBox(sabaki.getEngineName() + ' has resigned.')
+            sabaki.getRootTree().nodes[0].RE = [opponent + '+Resign']
             return
         }
 
         let v = [-1, -1]
         if (r.content.toLowerCase() != 'pass')
-            v = getBoard().coord2vertex(r.content)
+            v = sabaki.getBoard().coord2vertex(r.content)
 
-        $('#console').data('boardhash', getBoard().makeMove(view.getCurrentPlayer(), v).getHash())
-        makeMove(v, false)
+        $('#console').data('boardhash', sabaki.getBoard().makeMove(view.getCurrentPlayer(), v).getHash())
+        sabaki.makeMove(v, false)
     })
 }
 
-function centerGraphCameraAt(node) {
+sabaki.centerGraphCameraAt = function(node) {
     if (!view.getShowSidebar() || !node) return
 
     let s = $('#graph').data('sigma')
     s.renderers[0].resize().render()
 
-    let matrixdict = getGraphMatrixDict()
+    let matrixdict = sabaki.getGraphMatrixDict()
     let y = matrixdict[1][node.id][1]
 
     let wp = gametree.getSectionWidth(y, matrixdict[0])
@@ -1862,25 +1863,25 @@ function centerGraphCameraAt(node) {
     )
 }
 
-function askForSave() {
-    if (!getRootTree()) return true
-    let hash = generateFileHash()
+sabaki.askForSave = function() {
+    if (!sabaki.getRootTree()) return true
+    let hash = sabaki.generateFileHash()
 
-    if (hash != getFileHash()) {
+    if (hash != sabaki.getFileHash()) {
         let answer = view.showMessageBox(
             'Your changes will be lost if you close this file without saving.',
             'warning',
             ['Save', 'Don’t Save', 'Cancel'], 2
         )
 
-        if (answer == 0) saveFile(view.getRepresentedFilename())
+        if (answer == 0) sabaki.saveFile(view.getRepresentedFilename())
         else if (answer == 2) return false
     }
 
     return true
 }
 
-function startAutoScroll(direction, delay) {
+sabaki.startAutoScroll = function(direction, delay) {
     if (direction > 0 && !$('#sidebar .slider a.next').data('mousedown')
     || direction < 0 && !$('#sidebar .slider a.prev').data('mousedown')) return
 
@@ -1890,12 +1891,12 @@ function startAutoScroll(direction, delay) {
     let $slider = $('#sidebar .slider')
     clearTimeout($slider.data('autoscrollid'))
 
-    if (direction > 0) goForward()
-    else goBack()
-    updateSlider()
+    if (direction > 0) sabaki.goForward()
+    else sabaki.goBack()
+    sabaki.updateSlider()
 
     $slider.data('autoscrollid', setTimeout(() => {
-        startAutoScroll(direction, delay - setting.get('autoscroll.diff'))
+        sabaki.startAutoScroll(direction, delay - setting.get('autoscroll.diff'))
     }, delay))
 }
 
@@ -1903,14 +1904,14 @@ function startAutoScroll(direction, delay) {
  * Menu
  */
 
-function newFile(playSound) {
-    if (view.getIsBusy() || !askForSave()) return
+sabaki.newFile = function(playSound) {
+    if (view.getIsBusy() || !sabaki.askForSave()) return
 
     view.closeDrawers()
-    setGameTrees([getEmptyGameTree()])
+    sabaki.setGameTrees([sabaki.getEmptyGameTree()])
     view.setRepresentedFilename(null)
-    setGameIndex(0)
-    updateFileHash()
+    sabaki.setGameIndex(0)
+    sabaki.updateFileHash()
 
     if (playSound) {
         sound.playNewGame()
@@ -1918,8 +1919,8 @@ function newFile(playSound) {
     }
 }
 
-function loadFile(filename) {
-    if (view.getIsBusy() || !askForSave()) return
+sabaki.loadFile = function(filename) {
+    if (view.getIsBusy() || !sabaki.askForSave()) return
 
     if (!filename) {
         let result = dialog.showOpenDialog({
@@ -1931,14 +1932,14 @@ function loadFile(filename) {
     }
 
     if (filename) {
-        loadFileFromSgf(fs.readFileSync(filename, { encoding: 'binary' }), true, err => {
+        sabaki.loadFileFromSgf(fs.readFileSync(filename, { encoding: 'binary' }), true, err => {
             if (!err) view.setRepresentedFilename(filename)
         })
     }
 }
 
-function loadFileFromSgf(content, dontask = false, callback = () => {}) {
-    if (view.getIsBusy() || !dontask && !askForSave()) return
+sabaki.loadFileFromSgf = function(content, dontask = false, callback = () => {}) {
+    if (view.getIsBusy() || !dontask && !sabaki.askForSave()) return
     view.setIsBusy(true)
     view.closeDrawers()
 
@@ -1963,9 +1964,9 @@ function loadFileFromSgf(content, dontask = false, callback = () => {}) {
         }
 
         if (trees.length != 0) {
-            setGameTrees(trees)
-            setGameIndex(0)
-            updateFileHash()
+            sabaki.setGameTrees(trees)
+            sabaki.setGameIndex(0)
+            sabaki.updateFileHash()
         }
 
         if (trees.length > 1)
@@ -1977,7 +1978,7 @@ function loadFileFromSgf(content, dontask = false, callback = () => {}) {
     }, setting.get('app.loadgame_delay'))
 }
 
-function saveFile(filename) {
+sabaki.saveFile = function(filename) {
     if (view.getIsBusy()) return
     view.setIsBusy(true)
 
@@ -1988,16 +1989,16 @@ function saveFile(filename) {
     }
 
     if (filename) {
-        fs.writeFileSync(filename, saveFileToSgf())
-        updateFileHash()
+        fs.writeFileSync(filename, sabaki.saveFileToSgf())
+        sabaki.updateFileHash()
         view.setRepresentedFilename(filename)
     }
 
     view.setIsBusy(false)
 }
 
-function saveFileToSgf() {
-    let trees = getGameTrees()
+sabaki.saveFileToSgf = function() {
+    let trees = sabaki.getGameTrees()
     let text = ''
 
     for (let i = 0; i < trees.length; i++) {
@@ -2008,58 +2009,58 @@ function saveFileToSgf() {
     return text
 }
 
-function clearMarkup() {
+sabaki.clearMarkup = function() {
     view.closeDrawers()
     let markupIds = ['MA', 'TR', 'CR', 'SQ', 'LB', 'AR', 'LN']
 
     // Save undo information
-    setUndoable(true, 'Restore Markup')
+    sabaki.setUndoable(true, 'Restore Markup')
 
-    let [tree, index] = getCurrentTreePosition()
+    let [tree, index] = sabaki.getCurrentTreePosition()
     markupIds.forEach(id => delete tree.nodes[index][id])
 
-    setCurrentTreePosition(tree, index)
+    sabaki.setCurrentTreePosition(tree, index)
 }
 
-function goStep(step) {
+sabaki.goStep = function(step) {
     if (view.getGuessMode()) return
 
-    let [tree, index] = getCurrentTreePosition()
+    let [tree, index] = sabaki.getCurrentTreePosition()
     let tp = gametree.navigate(tree, index, step)
-    if (tp) setCurrentTreePosition(...tp)
+    if (tp) sabaki.setCurrentTreePosition(...tp)
 }
 
-function goBack() {
-    goStep(-1)
+sabaki.goBack = function() {
+    sabaki.goStep(-1)
 }
 
-function goForward() {
-    goStep(1)
+sabaki.goForward = function() {
+    sabaki.goStep(1)
 }
 
-function goToNextFork() {
-    let [tree, index] = getCurrentTreePosition()
+sabaki.goToNextFork = function() {
+    let [tree, index] = sabaki.getCurrentTreePosition()
 
     if (index != tree.nodes.length - 1)
-        setCurrentTreePosition(tree, tree.nodes.length - 1)
+        sabaki.setCurrentTreePosition(tree, tree.nodes.length - 1)
     else if (tree.current != null) {
         let subtree = tree.subtrees[tree.current]
-        setCurrentTreePosition(subtree, subtree.nodes.length - 1)
+        sabaki.setCurrentTreePosition(subtree, subtree.nodes.length - 1)
     }
 }
 
-function goToPreviousFork() {
-    let [tree, index] = getCurrentTreePosition()
+sabaki.goToPreviousFork = function() {
+    let [tree, index] = sabaki.getCurrentTreePosition()
 
     if (tree.parent == null || tree.parent.nodes.length == 0) {
-        if (index != 0) setCurrentTreePosition(tree, 0)
+        if (index != 0) sabaki.setCurrentTreePosition(tree, 0)
     } else {
-        setCurrentTreePosition(tree.parent, tree.parent.nodes.length - 1)
+        sabaki.setCurrentTreePosition(tree.parent, tree.parent.nodes.length - 1)
     }
 }
 
-function goToComment(step) {
-    let tp = getCurrentTreePosition()
+sabaki.goToComment = function(step) {
+    let tp = sabaki.getCurrentTreePosition()
 
     while (true) {
         tp = gametree.navigate(...tp, step)
@@ -2071,46 +2072,46 @@ function goToComment(step) {
             break
     }
 
-    if (tp) setCurrentTreePosition(...tp)
+    if (tp) sabaki.setCurrentTreePosition(...tp)
 }
 
-function goToBeginning() {
-    let tree = getRootTree()
+sabaki.goToBeginning = function() {
+    let tree = sabaki.getRootTree()
     if (tree.nodes.length == 0) return
-    setCurrentTreePosition(tree, 0)
+    sabaki.setCurrentTreePosition(tree, 0)
 }
 
-function goToEnd() {
-    let tree = getRootTree()
-    setCurrentTreePosition(...gametree.navigate(tree, 0, gametree.getCurrentHeight(tree) - 1))
+sabaki.goToEnd = function() {
+    let tree = sabaki.getRootTree()
+    sabaki.setCurrentTreePosition(...gametree.navigate(tree, 0, gametree.getCurrentHeight(tree) - 1))
 }
 
-function goToNextVariation() {
-    let [tree, index] = getCurrentTreePosition()
+sabaki.goToNextVariation = function() {
+    let [tree, index] = sabaki.getCurrentTreePosition()
 
     if (!tree.parent) return
 
     let mod = tree.parent.subtrees.length
     let i = (tree.parent.current + 1) % mod
 
-    setCurrentTreePosition(tree.parent.subtrees[i], 0)
+    sabaki.setCurrentTreePosition(tree.parent.subtrees[i], 0)
 }
 
-function goToPreviousVariation() {
-    let [tree, index] = getCurrentTreePosition()
+sabaki.goToPreviousVariation = function() {
+    let [tree, index] = sabaki.getCurrentTreePosition()
 
     if (!tree.parent) return
 
     let mod = tree.parent.subtrees.length
     let i = (tree.parent.current + mod - 1) % mod
 
-    setCurrentTreePosition(tree.parent.subtrees[i], 0)
+    sabaki.setCurrentTreePosition(tree.parent.subtrees[i], 0)
 }
 
-function goToMainVariation() {
-    let tp = getCurrentTreePosition()
+sabaki.goToMainVariation = function() {
+    let tp = sabaki.getCurrentTreePosition()
     let tree = tp[0]
-    let root = getRootTree()
+    let root = sabaki.getRootTree()
 
     while (!gametree.onMainTrack(tree)) {
         tree = tree.parent
@@ -2122,17 +2123,17 @@ function goToMainVariation() {
     }
 
     if (gametree.onMainTrack(tp[0])) {
-        setCurrentTreePosition(tree, tp[1], false, true)
+        sabaki.setCurrentTreePosition(tree, tp[1], false, true)
     } else {
-        setCurrentTreePosition(tree, tree.nodes.length - 1, false, true)
+        sabaki.setCurrentTreePosition(tree, tree.nodes.length - 1, false, true)
     }
 }
 
-function makeMainVariation(tree, index) {
-    setUndoable(true, 'Restore Main Variation')
+sabaki.makeMainVariation = function(tree, index) {
+    sabaki.setUndoable(true, 'Restore Main Variation')
     view.closeDrawers()
 
-    let root = getRootTree()
+    let root = sabaki.getRootTree()
     let level = gametree.getLevel(tree, index)
     let t = tree
 
@@ -2144,10 +2145,10 @@ function makeMainVariation(tree, index) {
         t = t.parent
     }
 
-    setCurrentTreePosition(tree, index, true, true)
+    sabaki.setCurrentTreePosition(tree, index, true, true)
 }
 
-function removeNode(tree, index) {
+sabaki.removeNode = function(tree, index) {
     if (!tree.parent && index == 0) {
         view.showMessageBox('The root node cannot be removed.', 'warning')
         return
@@ -2161,7 +2162,7 @@ function removeNode(tree, index) {
 
     // Save undo information
 
-    setUndoable(true, 'Undo Remove Node')
+    sabaki.setUndoable(true, 'Undo Remove Node')
 
     // Remove node
 
@@ -2181,12 +2182,12 @@ function removeNode(tree, index) {
         gametree.reduceTree(parent)
     }
 
-    setGraphMatrixDict(gametree.tree2matrixdict(getRootTree()))
-    if (!prev || getCurrentGraphNode()) prev = getCurrentTreePosition()
-    setCurrentTreePosition(...prev)
+    sabaki.setGraphMatrixDict(gametree.tree2matrixdict(sabaki.getRootTree()))
+    if (!prev || sabaki.getCurrentGraphNode()) prev = sabaki.getCurrentTreePosition()
+    sabaki.setCurrentTreePosition(...prev)
 }
 
-function undoBoard() {
+sabaki.undoBoard = function() {
     if ($('body').data('undodata-root') == null
     || $('body').data('undodata-pos') == null)
         return
@@ -2194,12 +2195,12 @@ function undoBoard() {
     view.setIsBusy(true)
 
     setTimeout(() => {
-        setRootTree($('body').data('undodata-root'))
+        sabaki.setRootTree($('body').data('undodata-root'))
 
-        let tp = gametree.navigate(getRootTree(), 0, $('body').data('undodata-pos'))
-        setCurrentTreePosition(...tp, true, true)
+        let tp = gametree.navigate(sabaki.getRootTree(), 0, $('body').data('undodata-pos'))
+        sabaki.setCurrentTreePosition(...tp, true, true)
 
-        setUndoable(false)
+        sabaki.setUndoable(false)
         view.setIsBusy(false)
     }, setting.get('edit.undo_delay'))
 }
@@ -2209,23 +2210,23 @@ function undoBoard() {
  */
 
 $(document).ready(function() {
-    loadSettings()
-    loadEngines()
-    prepareDragDropFiles()
-    prepareBars()
-    prepareEditTools()
-    prepareAutoplay()
-    prepareSidebar()
-    prepareSlider()
-    prepareConsole()
-    prepareGameInfo()
-    preparePreferences()
-    newFile()
+    sabaki.loadSettings()
+    sabaki.loadEngines()
+    sabaki.prepareDragDropFiles()
+    sabaki.prepareBars()
+    sabaki.prepareEditTools()
+    sabaki.prepareAutoplay()
+    sabaki.prepareSidebar()
+    sabaki.prepareSlider()
+    sabaki.prepareConsole()
+    sabaki.prepareGameInfo()
+    sabaki.preparePreferences()
+    sabaki.newFile()
 
     $('#main, #graph canvas:last-child, #graph .slider').on('mousewheel', function(evt) {
         evt.preventDefault()
-        if (evt.wheelDelta < 0) goForward()
-        else if (evt.wheelDelta > 0) goBack()
+        if (evt.wheelDelta < 0) sabaki.goForward()
+        else if (evt.wheelDelta > 0) sabaki.goBack()
     })
 }).on('keydown', function(evt) {
     if (evt.keyCode == 27) {
@@ -2239,9 +2240,9 @@ $(document).ready(function() {
 $(window).on('resize', function() {
     view.resizeBoard()
 }).on('beforeunload', function(evt) {
-    if (!askForSave()) evt.returnValue = 'false'
+    if (!sabaki.askForSave()) evt.returnValue = 'false'
 
-    detachEngine()
+    sabaki.detachEngine()
 
     let win = remote.getCurrentWindow()
     if (win.isMaximized() || win.isMinimized() || win.isFullScreen()) return

--- a/browser/index.js
+++ b/browser/index.js
@@ -979,13 +979,12 @@ sabaki.syncEngine = function() {
 
 sabaki.makeMove = function(vertex, sendCommand = null, ignoreAutoplay = false) {
     if (!view.getPlayMode() && !view.getAutoplayMode() && !view.getGuessMode()) return
-    if (sendCommand == null) sendCommand = sabaki.getEngineController() != null
+    if (sendCommand == null) sendCommand = view.getPlayMode() && sabaki.getEngineController() != null
 
     let pass = !sabaki.getBoard().hasVertex(vertex)
     if (!pass && sabaki.getBoard().arrangement[vertex] != 0) return
 
-    let position = sabaki.getCurrentTreePosition()
-    let tree = position[0], index = position[1]
+    let [tree, index] = sabaki.getCurrentTreePosition()
     let sign = view.getCurrentPlayer()
     let color = sign > 0 ? 'B' : 'W'
     let capture = false, suicide = false

--- a/browser/ipc.js
+++ b/browser/ipc.js
@@ -3,14 +3,18 @@ const view = require('./view')
 const setting = require('../modules/setting')
 
 let menudata = {
-    newfile: () => newFile(true),
+    newfile: () => sabaki.newFile(true),
     newwindow: () => ipcRenderer.send('new-window'),
-    loadfile: () => loadFile(),
-    savefile: () => saveFile(view.getRepresentedFilename()),
-    saveas: () => saveFile(),
-    loadclipboard: () => loadFileFromSgf(clipboard.readText(), false, () => view.setRepresentedFilename(null)),
-    copytoclipboard: () => clipboard.writeText(saveFileToSgf()),
-    copyascii: () => clipboard.writeText(getBoard().generateAscii()),
+    loadfile: () => sabaki.loadFile(),
+    savefile: () => sabaki.saveFile(view.getRepresentedFilename()),
+    saveas: () => sabaki.saveFile(),
+    loadclipboard: () => sabaki.loadFileFromSgf(
+        clipboard.readText(),
+        false,
+        () => view.setRepresentedFilename(null)
+    ),
+    copytoclipboard: () => clipboard.writeText(sabaki.saveFileToSgf()),
+    copyascii: () => clipboard.writeText(sabaki.getBoard().generateAscii()),
     managegames: () => view.showGameChooser(),
     score: () => view.setScoringMode(true),
     estimate: () => view.setEstimatorMode(true),
@@ -18,42 +22,51 @@ let menudata = {
     preferences: () => view.showPreferences(),
 
     editmode: () => view.setEditMode(!view.getEditMode()),
-    clearmarkup: () => clearMarkup(),
-    stonetool: () => setSelectedTool('stone'),
-    crosstool: () => setSelectedTool('cross'),
-    triangletool: () => setSelectedTool('triangle'),
-    squaretool: () => setSelectedTool('square'),
-    circletool: () => setSelectedTool('circle'),
-    linetool: () => setSelectedTool('line'),
-    labeltool: () => setSelectedTool('label'),
-    numbertool: () => setSelectedTool('number'),
-    pass: () => makeMove([-1, -1]),
-    resign: () => makeResign(),
-    removenode: () => removeNode(...getCurrentTreePosition()),
-    makemainvariation: () => makeMainVariation(...getCurrentTreePosition()),
+    clearmarkup: () => sabaki.clearMarkup(),
+    stonetool: () => sabaki.setSelectedTool('stone'),
+    crosstool: () => sabaki.setSelectedTool('cross'),
+    triangletool: () => sabaki.setSelectedTool('triangle'),
+    squaretool: () => sabaki.setSelectedTool('square'),
+    circletool: () => sabaki.setSelectedTool('circle'),
+    linetool: () => sabaki.setSelectedTool('line'),
+    labeltool: () => sabaki.setSelectedTool('label'),
+    numbertool: () => sabaki.setSelectedTool('number'),
+    pass: () => sabaki.makeMove([-1, -1]),
+    resign: () => sabaki.makeResign(),
+    removenode: () => sabaki.removeNode(...sabaki.getCurrentTreePosition()),
+    makemainvariation: () => sabaki.makeMainVariation(...sabaki.getCurrentTreePosition()),
 
     findmode: () => view.setFindMode(!view.getFindMode()),
-    findnext: () => { view.setFindMode(true); findMove(view.getIndicatorVertex(), view.getFindText(), 1) },
-    findprevious: () => { view.setFindMode(true); findMove(view.getIndicatorVertex(), view.getFindText(), -1) },
-    togglehotspot: () => setHotspot(!getHotspot()),
-    nexthotspot: () => findBookmark(1),
-    previoushotspot: () => findBookmark(-1),
+    findnext: () => {
+        view.setFindMode(true)
+        sabaki.findMove(view.getIndicatorVertex(), view.getFindText(), 1)
+    },
+    findprevious: () => {
+        view.setFindMode(true)
+        sabaki.findMove(view.getIndicatorVertex(), view.getFindText(), -1)
+    },
+    togglehotspot: () => sabaki.setHotspot(!sabaki.getHotspot()),
+    nexthotspot: () => sabaki.findBookmark(1),
+    previoushotspot: () => sabaki.findBookmark(-1),
 
-    goback: () => goBack(),
-    goforward: () => goForward(),
-    gotopreviousfork: () => goToPreviousFork(),
-    gotonextfork: () => goToNextFork(),
-    nextcomment: () => goToComment(1),
-    previouscomment: () => goToComment(-1),
-    gotobeginning: () => goToBeginning(),
-    gotoend: () => goToEnd(),
-    gotonextvariation: () => goToNextVariation(),
-    gotopreviousvariation: () => goToPreviousVariation(),
-    gotomainvariation: () => goToMainVariation(),
+    goback: () => sabaki.goBack(),
+    goforward: () => sabaki.goForward(),
+    gotopreviousfork: () => sabaki.goToPreviousFork(),
+    gotonextfork: () => sabaki.goToNextFork(),
+    nextcomment: () => sabaki.goToComment(1),
+    previouscomment: () => sabaki.goToComment(-1),
+    gotobeginning: () => sabaki.goToBeginning(),
+    gotoend: () => sabaki.goToEnd(),
+    gotonextvariation: () => sabaki.goToNextVariation(),
+    gotopreviousvariation: () => sabaki.goToPreviousVariation(),
+    gotomainvariation: () => sabaki.goToMainVariation(),
 
-    manageengines: () => { view.showPreferences(); view.setPreferencesTab('engines') },
-    detachengine: () => detachEngine(),
-    generatemove: () => generateMove(),
+    manageengines: () => {
+        view.showPreferences()
+        view.setPreferencesTab('engines')
+    },
+    detachengine: () => sabaki.detachEngine(),
+    generatemove: () => sabaki.generateMove(),
     gtpconsole: () => view.setShowLeftSidebar(!view.getShowLeftSidebar()),
     clearconsole: () => view.clearConsole(),
 
@@ -72,8 +85,8 @@ let menudata = {
 }
 
 ipcRenderer.on('menu-click', (e, action) => menudata[action]())
-ipcRenderer.on('attach-engine', (e, path, args) => attachEngine(path, args))
+ipcRenderer.on('attach-engine', (e, path, args) => sabaki.attachEngine(path, args))
 
 ipcRenderer.on('load-file', (e, path) => {
-    setTimeout(() => loadFile(path), setting.get('app.loadgame_delay'))
+    setTimeout(() => sabaki.loadFile(path), setting.get('app.loadgame_delay'))
 })

--- a/browser/view.js
+++ b/browser/view.js
@@ -158,9 +158,9 @@ exports.setShowSidebar = function(show) {
     $('#main').css('right', show ? setting.get('view.sidebar_width') : 0)
 
     if (show) {
-        updateGraph()
-        updateSlider()
-        updateCommentText();
+        sabaki.updateGraph()
+        sabaki.updateSlider()
+        sabaki.updateCommentText();
     } else {
         // Clear game graph
         let sigma = $('#graph').data('sigma')
@@ -434,7 +434,7 @@ exports.setAutoplayMode = function(autoplayMode) {
         $('body').addClass('autoplay')
     } else {
         $('body').removeClass('autoplay')
-        setAutoplaying(false)
+        sabaki.setAutoplaying(false)
     }
 }
 
@@ -456,10 +456,10 @@ exports.setScoringMode = function(mode, estimator) {
         exports.closeDrawers()
         $('body').addClass(type)
 
-        let deadstones = estimator ? getBoard().guessDeadStones() : getBoard().determineDeadStones()
+        let deadstones = estimator ? sabaki.getBoard().guessDeadStones() : sabaki.getBoard().determineDeadStones()
         deadstones.forEach(v => $('#goban .pos_' + v.join('-')).addClass('dead'))
 
-        updateAreaMap(estimator)
+        sabaki.updateAreaMap(estimator)
     } else {
         $('body').removeClass(type)
     }
@@ -520,8 +520,8 @@ exports.getShapes = function() {
 }
 
 exports.getCurrentMoveInterpretation = function() {
-    let board = getBoard()
-    let [tree, index] = getCurrentTreePosition()
+    let board = sabaki.getBoard()
+    let [tree, index] = sabaki.getCurrentTreePosition()
     let node = tree.nodes[index]
 
     // Determine root node
@@ -544,7 +544,7 @@ exports.getCurrentMoveInterpretation = function() {
     // Determine end of main variation
 
     if (gametree.onMainTrack(tree) && !gametree.navigate(tree, index, 1)) {
-        let rootNode = getRootTree().nodes[0]
+        let rootNode = sabaki.getRootTree().nodes[0]
 
         if ('RE' in rootNode && rootNode.RE[0].trim() != '')
             return 'Result: ' + rootNode.RE[0]
@@ -798,7 +798,7 @@ exports.updateTitle = function() {
     let filename = exports.getRepresentedFilename()
 
     if (filename) title = basename(filename)
-    if (getGameTrees().length > 1) title += ' — Game ' + (getGameIndex() + 1)
+    if (sabaki.getGameTrees().length > 1) title += ' — Game ' + (sabaki.getGameIndex() + 1)
     if (filename && process.platform != 'darwin') title += ' — ' + app.getName()
 
     document.title = title
@@ -936,7 +936,7 @@ exports.updateSidebarLayout = function() {
 }
 
 exports.buildBoard = function() {
-    let board = getBoard()
+    let board = sabaki.getBoard()
     let rows = []
     let hoshi = board.getHandicapPlacement(9)
 
@@ -977,24 +977,24 @@ exports.buildBoard = function() {
                     if (!$('#goban').data('mousedown')) return
 
                     $('#goban').data('mousedown', false)
-                    vertexClicked(this, evt)
+                    sabaki.vertexClicked(this, evt)
                 }.bind(vertex))
                 .on('touchend', function(evt) {
-                    if (!exports.getEditMode() || ['line', 'arrow'].indexOf(getSelectedTool()) < 0)
+                    if (!exports.getEditMode() || ['line', 'arrow'].indexOf(sabaki.getSelectedTool()) < 0)
                         return
 
                     evt.preventDefault()
-                    vertexClicked(null, { button: 0 })
+                    sabaki.vertexClicked(null, { button: 0 })
                 })
                 .on('mousemove', function(evt) {
                     if (!$('#goban').data('mousedown')) return
                     if (evt.button != 0) return
 
-                    drawLine(this)
+                    sabaki.drawLine(this)
                 }.bind(vertex))
                 .on('touchmove', function(evt) {
                     e.preventDefault()
-                    drawLine(getEndTargetVertex(evt))
+                    sabaki.drawLine(getEndTargetVertex(evt))
                 })
                 .on('mousedown', function() {
                     $('#goban').data('mousedown', true)
@@ -1061,7 +1061,7 @@ exports.updateBoardLines = function() {
 }
 
 exports.resizeBoard = function() {
-    let board = getBoard()
+    let board = sabaki.getBoard()
     if (!board) return
 
     let $main = $('main')
@@ -1158,16 +1158,16 @@ exports.wireLinks = function($container) {
             evt.preventDefault()
 
             let movenumber = +$(this).text().slice(1)
-            setUndoable(true, 'Go Back')
-            goToMainVariation()
+            sabaki.setUndoable(true, 'Go Back')
+            sabaki.goToMainVariation()
 
-            let tp = gametree.navigate(getRootTree(), 0, movenumber)
-            if (tp) setCurrentTreePosition(...tp, true, true)
+            let tp = gametree.navigate(sabaki.getRootTree(), 0, movenumber)
+            if (tp) sabaki.setCurrentTreePosition(...tp, true, true)
         }
     })
 
     $container.find('.coord').on('mouseenter', function() {
-        let v = getBoard().coord2vertex($(this).text())
+        let v = sabaki.getBoard().coord2vertex($(this).text())
         exports.showIndicator(v)
     }).on('mouseleave', function() {
         if (!exports.getFindMode()) exports.hideIndicator()
@@ -1182,11 +1182,11 @@ exports.openHeaderMenu = function() {
     let template = [
         {
             label: '&Pass',
-            click: () => makeMove([-1, -1])
+            click: () => sabaki.makeMove([-1, -1])
         },
         {
             label: '&Resign',
-            click: () => makeResign()
+            click: () => sabaki.makeResign()
         },
         { type: 'separator' },
         {
@@ -1221,7 +1221,7 @@ exports.openHeaderMenu = function() {
 }
 
 exports.openCommentMenu = function() {
-    let tp = getCurrentTreePosition()
+    let tp = sabaki.getCurrentTreePosition()
     let node = tp[0].nodes[tp[1]]
 
     let clearProperties = properties => properties.forEach(p => delete node[p])
@@ -1235,7 +1235,7 @@ exports.openCommentMenu = function() {
             click: () => {
                 clearPosAnnotations()
                 clearMoveAnnotations()
-                updateSidebar(true, true)
+                sabaki.updateSidebar(true, true)
             }
         },
         {type: 'separator'},
@@ -1311,7 +1311,7 @@ exports.openCommentMenu = function() {
                 node[p] = [value]
             }
 
-            setCurrentTreePosition(...getCurrentTreePosition(), true, true)
+            sabaki.setCurrentTreePosition(...sabaki.getCurrentTreePosition(), true, true)
         }
     })
 
@@ -1373,11 +1373,11 @@ exports.openNodeMenu = function(tree, index, position) {
     let template = [
         {
             label: 'Make &Main Variation',
-            click: () => makeMainVariation(tree, index)
+            click: () => sabaki.makeMainVariation(tree, index)
         },
         {
             label: '&Remove',
-            click: () => removeNode(tree, index)
+            click: () => sabaki.removeNode(tree, index)
         }
     ]
 
@@ -1390,7 +1390,7 @@ exports.openGameMenu = function($element, position) {
         {
             label: '&Remove Game',
             click: () => {
-                let trees = getGameTrees()
+                let trees = sabaki.getGameTrees()
 
                 if (exports.showMessageBox(
                     'Do you really want to remove this game permanently?',
@@ -1403,14 +1403,14 @@ exports.openGameMenu = function($element, position) {
                     .indexOf($element.get(0))
 
                 trees.splice(index, 1)
-                setGameTrees(trees)
+                sabaki.setGameTrees(trees)
 
                 if (trees.length == 0) {
-                    trees.push(getEmptyGameTree())
-                    setGameIndex(0)
+                    trees.push(sabaki.getEmptyGameTree())
+                    sabaki.setGameIndex(0)
                     exports.closeGameChooser()
                 } else {
-                    setGameIndex(0)
+                    sabaki.setGameIndex(0)
                     exports.showGameChooser(true)
                 }
             }
@@ -1424,8 +1424,8 @@ exports.openGameMenu = function($element, position) {
                     ['Remove Games', 'Cancel'], 1
                 ) == 1) return
 
-                setGameTrees([$element.parents('li').eq(0).data('gametree')])
-                setGameIndex(0)
+                sabaki.setGameTrees([$element.parents('li').eq(0).data('gametree')])
+                sabaki.setGameIndex(0)
                 exports.showGameChooser(true)
             }
         }
@@ -1440,10 +1440,10 @@ exports.openAddGameMenu = function() {
         {
             label: 'Add &New Game',
             click: () => {
-                let tree = getEmptyGameTree()
+                let tree = sabaki.getEmptyGameTree()
 
-                setGameTrees(getGameTrees().concat([tree]))
-                setGameIndex(getGameTrees().length - 1)
+                sabaki.setGameTrees(sabaki.getGameTrees().concat([tree]))
+                sabaki.setGameIndex(sabaki.getGameTrees().length - 1)
                 exports.showGameChooser('bottom')
             }
         },
@@ -1461,8 +1461,8 @@ exports.openAddGameMenu = function() {
                     filenames.forEach(filename => {
                         let trees = sgf.parseFile(filename).subtrees
 
-                        setGameTrees(getGameTrees().concat(trees))
-                        setGameIndex(getGameIndex())
+                        sabaki.setGameTrees(sabaki.getGameTrees().concat(trees))
+                        sabaki.setGameIndex(sabaki.getGameIndex())
                         exports.showGameChooser('bottom')
                     })
                 }
@@ -1488,7 +1488,7 @@ exports.openAddGameMenu = function() {
 exports.showGameInfo = function() {
     exports.closeDrawers()
 
-    let tree = getRootTree()
+    let tree = sabaki.getRootTree()
     let rootNode = tree.nodes[0]
     let $info = $('#info')
     let data = {
@@ -1510,8 +1510,8 @@ exports.showGameInfo = function() {
     $info.find('input[name="name_1"]').val(gametree.getPlayerName(1, tree, ''))
     $info.find('input[name="name_-1"]').val(gametree.getPlayerName(-1, tree, ''))
     $info.find('input[name="komi"]').val('KM' in rootNode ? +rootNode.KM[0] : '')
-    $info.find('input[name="size-width"]').val(getBoard().width)
-    $info.find('input[name="size-height"]').val(getBoard().height)
+    $info.find('input[name="size-width"]').val(sabaki.getBoard().width)
+    $info.find('input[name="size-height"]').val(sabaki.getBoard().height)
     $info.find('section .menu').removeClass('active').data('engineindex', -1)
 
     let handicap = $info.find('select[name="handicap"]').get(0)
@@ -1534,7 +1534,7 @@ exports.closeGameInfo = function() {
 exports.showScore = function() {
     let board = $('#goban').data('finalboard')
     let score = board.getScore($('#goban').data('areamap'))
-    let rootNode = getRootTree().nodes[0]
+    let rootNode = sabaki.getRootTree().nodes[0]
 
     for (let sign = -1; sign <= 1; sign += 2) {
         let $tr = $('#score tbody tr' + (sign < 0 ? ':last-child' : ''))
@@ -1543,10 +1543,10 @@ exports.showScore = function() {
         $tds.eq(0).text(score['area_' + sign])
         $tds.eq(1).text(score['territory_' + sign])
         $tds.eq(2).text(score['captures_' + sign])
-        if (sign < 0) $tds.eq(3).text(getKomi())
+        if (sign < 0) $tds.eq(3).text(sabaki.getKomi())
         $tds.eq(4).text(0)
 
-        setScoringMethod(setting.get('scoring.method'))
+        sabaki.setScoringMethod(setting.get('scoring.method'))
     }
 
     $('#score').addClass('show')
@@ -1562,7 +1562,7 @@ exports.showPreferences = function() {
     $('#preferences input[type="checkbox"]').get()
         .forEach(el => el.checked = !!setting.get(el.name))
 
-    loadEngines()
+    sabaki.loadEngines()
 
     // Show preferences
 
@@ -1594,8 +1594,8 @@ exports.showGameChooser = function(restoreScrollbarPos = true) {
     $('#gamechooser > input').eq(0).val('').get(0).focus()
     $('#gamechooser ol').eq(0).empty()
 
-    let trees = getGameTrees()
-    let currentTree = getRootTree()
+    let trees = sabaki.getGameTrees()
+    let currentTree = sabaki.getRootTree()
 
     for (let i = 0; i < trees.length; i++) {
         let tree = trees[i]
@@ -1623,7 +1623,7 @@ exports.showGameChooser = function(restoreScrollbarPos = true) {
             let link = this
             exports.closeGameChooser()
             setTimeout(() => {
-                setGameIndex($('#gamechooser ol li div').get().indexOf(link))
+                sabaki.setGameIndex($('#gamechooser ol li div').get().indexOf(link))
             }, 500)
         }).on('mouseup', function(evt) {
             if (evt.button != 2) return
@@ -1666,10 +1666,10 @@ exports.showGameChooser = function(restoreScrollbarPos = true) {
         if (afterli && afterli != dragged) $(afterli).before(dragged)
         if (beforeli && beforeli != dragged) $(beforeli).after(dragged)
 
-        setGameTrees($('#gamechooser ol > li').get().map(x => $(x).data('gametree')))
+        sabaki.setGameTrees($('#gamechooser ol > li').get().map(x => $(x).data('gametree')))
 
-        let newindex = getGameTrees().indexOf(currentTree)
-        setGameIndex(newindex)
+        let newindex = sabaki.getGameTrees().indexOf(currentTree)
+        sabaki.setGameIndex(newindex)
     })
 
     $('#gamechooser').addClass('show')

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "sigma": "^1.0.3"
   },
   "devDependencies": {
+    "mocha": "^3.0.2",
     "tmp": "^0.0.28"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "electron-packager": "^8.0.0",
     "mocha": "^3.0.2",
-    "tmp": "^0.0.28"
+    "tmp": "^0.0.29"
   },
   "scripts": {
     "test": "mocha",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "sigma": "^1.0.3"
   },
   "devDependencies": {
+    "electron-packager": "^8.0.0",
     "mocha": "^3.0.2",
     "tmp": "^0.0.28"
   },


### PR DESCRIPTION
This PR puts all functions in `index.js` in a global object named `sabaki`. This prevents Sabaki from polluting the global namespace and also sets the foundation of a Sabaki API (see #112). Since `index.js` and `view.js` depend on each other and `browserify` has trouble with circular dependencies, putting the functions into a global object may solve the problem.

Testing:

- [x] Open & save files
- [x] Manage multiple games
- [x] Score & estimate
- [x] Find & hotspots
- [x] Navigation
- [x] Autoplay
- [x] Guess mode
- [x] Engines
- [x] Preferences & game info
- [x] SGF tools
- [x] Comments & move annotations
- [x] Graph & slider
- [x] Resizers
- [x] Menu items