### PR TITLE
Use boardsize when creating Board for .getHandicapPlacement()

### DIFF
--- a/modules/ngf.js
+++ b/modules/ngf.js
@@ -120,7 +120,7 @@ exports.parse = function (content, callback = () => {}) {      // We ignore the 
         root.HA = [handicap]
         root.AB = []
 
-        let tmp = new Board()       // Created solely for .getHandicapPlacement()
+        let tmp = new Board(boardsize, boardsize)       // Created solely for .getHandicapPlacement()
 
         let points = tmp.getHandicapPlacement(handicap)
 


### PR DESCRIPTION
This fixes handicap placement for NGF when the board is not 19x19. (I
think GIB is always 19x19).