### PR TITLE
Allow stone overwrites

### DIFF
--- a/modules/board.js
+++ b/modules/board.js
@@ -380,9 +380,6 @@ class Board {
 
         if (sign === 0 || !this.hasVertex(vertex)) return move
 
-        // Next line commented out to allow moves to overwrite stones...
-        // if (this.get(vertex) !== 0) return null
-
         sign = sign > 0 ? 1 : -1
         move.set(vertex, sign)
 

--- a/modules/board.js
+++ b/modules/board.js
@@ -379,7 +379,9 @@ class Board {
         let move = new Board(this.width, this.height, this.arrangement, this.captures)
 
         if (sign === 0 || !this.hasVertex(vertex)) return move
-        if (this.get(vertex) !== 0) return null
+
+        // Next line commented out to allow moves to overwrite stones...
+        // if (this.get(vertex) !== 0) return null
 
         sign = sign > 0 ? 1 : -1
         move.set(vertex, sign)
@@ -392,7 +394,7 @@ class Board {
         for (let n of deadNeighbors) {
             if (move.get(n) === 0) continue
 
-            for (let c of this.getChain(n)) {
+            for (let c of move.getChain(n)) {
                 move.set(c, 0)
                 move.captures[sign.toString()]++
             }

--- a/test/boardTests.js
+++ b/test/boardTests.js
@@ -266,6 +266,15 @@ describe('Board', () => {
             assert.equal(move.get([3, 1]), 1)
             assert.equal(move.get([1, 2]), 1)
         })
+        it('should handle stone overwrites correctly' () => {
+            let board = new Board()
+            ;[[10, 9], [10, 10], [10, 11]].forEach(x => board.set(x, 1))
+            ;[[10, 8], [9, 9], [11, 9]].forEach(x => board.set(x, -1))
+            let move = board.makeMove(-1, [10, 10])
+            assert.equal(move.get([10, 10]), -1)
+            assert.equal(move.get([10, 9]), 0)
+            assert.equal(move.get([10, 11]), 1)
+        })
         it('should make a pass', () => {
             let board = new Board()
             assert.deepEqual(board.makeMove(1, [-1, -1]).arrangement, board.arrangement)

--- a/test/boardTests.js
+++ b/test/boardTests.js
@@ -266,7 +266,7 @@ describe('Board', () => {
             assert.equal(move.get([3, 1]), 1)
             assert.equal(move.get([1, 2]), 1)
         })
-        it('should handle stone overwrites correctly' () => {
+        it('should handle stone overwrites correctly', () => {
             let board = new Board()
             ;[[10, 9], [10, 10], [10, 11]].forEach(x => board.set(x, 1))
             ;[[10, 8], [9, 9], [11, 9]].forEach(x => board.set(x, -1))


### PR DESCRIPTION
This allows stones to be overwritten.

I trust that makeMove() is never called as a legality checker, i.e. you never call it just to check the result isn't null. Currently, that seems to be true.

Closes #182.