### PR TITLE
Allow detection of charset if CA not present

### DIFF
--- a/modules/sgf.js
+++ b/modules/sgf.js
@@ -146,8 +146,8 @@ exports.parse = function(input, callback, ignoreEncoding = false) {
 
     if (ignoreEncoding === false) {
         let found_encoding = false
-        for (let i = 0; i < tokens.length; i += 1) {
-            if (tokens[i][0] === 'prop_ident' && tokens[i][1] === 'CA') {
+        for (let t of tokens) {
+            if (t[0] === 'prop_ident' && t[1] === 'CA') {
                 found_encoding = true
                 break
             }

--- a/modules/sgf.js
+++ b/modules/sgf.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const iconv = require('iconv-lite')
+const jschardet = require('jschardet')
 const gametree = require('./gametree')
 const setting = require('./setting')
 const helper = require('./helper')
@@ -131,14 +132,35 @@ function _parseTokens(tokens, callback = () => {}, encoding = defaultEncoding, s
     return tree
 }
 
-exports.parseTokens = function(tokens, callback, ignoreEncoding = false) {
-    let tree = _parseTokens(tokens, callback, ignoreEncoding ? null : undefined)
+exports.parseTokens = function(tokens, callback, encoding = defaultEncoding) {
+    let tree = _parseTokens(tokens, callback, encoding)
     tree.subtrees.forEach(subtree => subtree.parent = null)
     return tree.subtrees
 }
 
 exports.parse = function(input, callback, ignoreEncoding = false) {
-    return exports.parseTokens(exports.tokenize(input), callback, ignoreEncoding)
+
+    let tokens = exports.tokenize(input)
+
+    let encoding = ignoreEncoding ? null : defaultEncoding
+
+    if (ignoreEncoding === false) {
+        let found_encoding = false
+        for (let i = 0; i < tokens.length; i += 1) {
+            if (tokens[i][0] === 'prop_ident' && tokens[i][1] === 'CA') {
+                found_encoding = true
+                break
+            }
+        }
+        if (found_encoding === false) {
+            let detected = jschardet.detect(input)
+            if (detected.confidence > 0.2) {
+                encoding = detected.encoding
+            }
+        }
+    }
+
+    return exports.parseTokens(tokens, callback, encoding)
 }
 
 exports.parseFile = function(filename, callback, ignoreEncoding = false) {

--- a/modules/sgf.js
+++ b/modules/sgf.js
@@ -139,20 +139,19 @@ exports.parseTokens = function(tokens, callback, encoding = defaultEncoding) {
 }
 
 exports.parse = function(input, callback, ignoreEncoding = false) {
-
     let tokens = exports.tokenize(input)
 
     let encoding = ignoreEncoding ? null : defaultEncoding
 
     if (ignoreEncoding === false) {
-        let found_encoding = false
+        let foundEncoding = false
         for (let t of tokens) {
             if (t[0] === 'prop_ident' && t[1] === 'CA') {
-                found_encoding = true
+                foundEncoding = true
                 break
             }
         }
-        if (found_encoding === false) {
+        if (foundEncoding === false) {
             let detected = jschardet.detect(input)
             if (detected.confidence > 0.2) {
                 encoding = detected.encoding

--- a/test/sgfTests.js
+++ b/test/sgfTests.js
@@ -129,10 +129,10 @@ describe('sgf', () => {
             )
         })
         it('should auto-detect GB2312 encoding if given enough data', () => {
-        	assert.equal(
-        		sgf.parse('(;GM[1]FF[4]SZ[19]PB[\xBD\xA3\xB9\xFD\xCE\xDE\xC9\xF9])')[0].nodes[0].PB[0],                           // GB2312
-        		sgf.parse('(;GM[1]FF[4]SZ[19]CA[UTF-8]PB[\xE5\x89\x91\xE8\xBF\x87\xE6\x97\xA0\xE5\xA3\xB0])')[0].nodes[0].PB[0]   // UTF-8
-        	)
+            assert.equal(
+                sgf.parse('(;GM[1]FF[4]SZ[19]PB[\xBD\xA3\xB9\xFD\xCE\xDE\xC9\xF9])')[0].nodes[0].PB[0],                           // GB2312
+                sgf.parse('(;GM[1]FF[4]SZ[19]CA[UTF-8]PB[\xE5\x89\x91\xE8\xBF\x87\xE6\x97\xA0\xE5\xA3\xB0])')[0].nodes[0].PB[0]   // UTF-8
+            )
         })
     })
 

--- a/test/sgfTests.js
+++ b/test/sgfTests.js
@@ -128,6 +128,12 @@ describe('sgf', () => {
                 })
             )
         })
+        it('should auto-detect GB2312 encoding if given enough data', () => {
+        	assert.equal(
+        		sgf.parse('(;GM[1]FF[4]SZ[19]PB[\xBD\xA3\xB9\xFD\xCE\xDE\xC9\xF9])')[0].nodes[0].PB[0],                           // GB2312
+        		sgf.parse('(;GM[1]FF[4]SZ[19]CA[UTF-8]PB[\xE5\x89\x91\xE8\xBF\x87\xE6\x97\xA0\xE5\xA3\xB0])')[0].nodes[0].PB[0]   // UTF-8
+        	)
+        })
     })
 
     describe('encoding', () => {


### PR DESCRIPTION
Note that I had to change the signature of exports.parseTokens(), its
third argument is now an encoding (possibly null) instead of
ignoreEncoding.

Closes #188