### PR TITLE
trying to fix incorrect komi value sent to gtp

### DIFF
--- a/components/App.js
+++ b/components/App.js
@@ -1885,7 +1885,7 @@ class App extends Component {
     attachEngines(...engines) {
         let {engineCommands, attachedEngines} = this.state
 
-        if (helper.vertexEquals([engines[1], engines[0]], attachedEngines)) {
+        if (helper.vertexEquals([...engines].reverse(), attachedEngines)) {
             // Just swap engines
 
             this.attachedEngineControllers.reverse()
@@ -2033,9 +2033,9 @@ class App extends Component {
 
                 this.sendGTPCommand(controller, new gtp.Command(null, 'boardsize', board.width))
                 this.sendGTPCommand(controller, new gtp.Command(null, 'clear_board'))
-                
-                let komi = gametree.getRootProperty(this.state.treePosition[0], 'KM')
-                this.sendGTPCommand(controller, new gtp.Command(null, 'komi', komi || 0))
+
+                let komi = gametree.getRootProperty(this.state.treePosition[0], 'KM', 0)
+                this.sendGTPCommand(controller, new gtp.Command(null, 'komi', komi))
 
                 for (let x = 0; x < board.width; x++) {
                     for (let y = 0; y < board.height; y++) {

--- a/components/App.js
+++ b/components/App.js
@@ -2033,7 +2033,9 @@ class App extends Component {
 
                 this.sendGTPCommand(controller, new gtp.Command(null, 'boardsize', board.width))
                 this.sendGTPCommand(controller, new gtp.Command(null, 'clear_board'))
-                this.sendGTPCommand(controller, new gtp.Command(null, 'komi', this.inferredState.gameInfo.komi || 0))
+                
+                let komi = gametree.getRootProperty(root, 'KM')
+                this.sendGTPCommand(controller, new gtp.Command(null, 'komi', komi || 0))
 
                 for (let x = 0; x < board.width; x++) {
                     for (let y = 0; y < board.height; y++) {

--- a/components/App.js
+++ b/components/App.js
@@ -2034,7 +2034,7 @@ class App extends Component {
                 this.sendGTPCommand(controller, new gtp.Command(null, 'boardsize', board.width))
                 this.sendGTPCommand(controller, new gtp.Command(null, 'clear_board'))
                 
-                let komi = gametree.getRootProperty(root, 'KM')
+                let komi = gametree.getRootProperty(this.state.treePosition[0], 'KM')
                 this.sendGTPCommand(controller, new gtp.Command(null, 'komi', komi || 0))
 
                 for (let x = 0; x < board.width; x++) {

--- a/components/drawers/InfoDrawer.js
+++ b/components/drawers/InfoDrawer.js
@@ -115,15 +115,10 @@ class InfoDrawer extends Component {
         }
 
         this.handleInputChange = [
-            'blackRank',
-            'blackName',
-            'whiteRank',
-            'whiteName',
-            'gameName',
-            'eventName',
-            'komi',
-            'result',
-            'handicap'
+            'blackRank', 'blackName',
+            'whiteRank', 'whiteName',
+            'gameName', 'eventName',
+            'komi', 'result', 'handicap'
         ].reduce((acc, key) => {
             acc[key] = ({currentTarget}) => {
                 this.setState({[key]: currentTarget.value === '' ? null : currentTarget.value})


### PR DESCRIPTION
When both changing the komi value of an opened sgf file and attaching a gtp engine _during a single visit of the info drawer_, the old komi value remaining in inferredState is used in syncEngines() after the button 'OK' is clicked. This causes the old komi value being sent to gtp in the initialization of the engine. I try to fix this bug with this commit. Not sure my fix is proper though. Please check, thanks.